### PR TITLE
Add webpack loader to carmi

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -1,0 +1,15 @@
+// Usage: `require('carmi/loader!./file.carmi')`
+// or just setup as a default loader for `.carmi.js$` files
+
+'use strict'
+
+const {compile} = require('carmi');
+
+module.exports = function CarmiLoader() {
+    const callback = this.async();
+    const carmiModuleSourcePath = this.getDependencies()[0];
+    const carmiModule = require(carmiModuleSourcePath);
+    compile(carmiModule, {compiler: 'optimizing', format: 'cjs'}).then(compiledCode => {
+        callback(null, compiledCode);
+    }).catch(err => callback(err));
+};


### PR DESCRIPTION
Hi @avi!

What do you think about implementing a simple webpack loader for using Carmi? (instead of adding another build step)
In the future, we can implement parameters (like `carmi/loader?compiler=simple&format=...`) and maybe even source maps!

Using the module is as simple as `require('carmi/loader!./file.carmi')`.
We can also just set it up as a default loader for `.carmi.js$` files, and then go bananas with `require('./myModel.carmi')` 😸 