### PR TITLE
Babel plugin: idempotent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ yarn.lock
 Cargo.lock
 /rust/src
 /rust/target
+*.compiled.carmi.js


### PR DESCRIPTION
* Leave a watermark so we know this file was already compiled
* Don't add `carmi` as a dependency, even for webpack

the way it works:

```js
const {root} = require('carmi')
module.exports = {first: root.get(0)}
```

compiles to

```js
'carmi-compiled';

module.exports = CARMI_COMPILED_RESULT
```

with the directive added, we now know that we need to ignore that file if we compile it next time 😸 