### PR TITLE
Use magic comment with Babel plugin as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,19 @@ console.log(todos.todosDisplay);
 
 ## Usage with Babel Macros
 
+### Using a magic comment
+
+```js
+// @carmi
+
+require('carmi/macro') // Activate the macro!
+
+const { root } = require('carmi')
+module.exports = { first: root.get(0) }
+```
+
+### Using string literals
+
 ```js
 const carmi = require('carmi/macro')
 
@@ -83,13 +96,13 @@ const model = modelBuilder(["first", "second"])
 console.log(model.first) // prints "first"!
 ```
 
-## Usage with Babel
+## Usage with Babel (as a plugin)
 
 Compiles Carmi files (`xxx.carmi.js`) automatically using Babel. It reserves the external modules, required by `require`,
 in order to help bundlers (like webpack) understand dependencies across Carmi models (and to help them watch the files).
 
 ```js
-// model.carmi.js
+// @carmi
 
 const { root } = require("carmi");
 const { second } = require("./anotherModel.carmi.js");

--- a/src/babelPlugin/index.spec.js
+++ b/src/babelPlugin/index.spec.js
@@ -63,6 +63,7 @@ it("adds require statements for dependencies", () => {
   jest.resetModules();
   const plugin = require("./index");
   const original = `
+    // @carmi
     const {root} = require('carmi')
     const {resolve} = require('path')
     const _ = require('lodash')
@@ -79,4 +80,20 @@ it("adds require statements for dependencies", () => {
     code.match(requiresRegex).map(e => e.match(requireArgumentRegex)[1])
   );
   expect(dependencies).toEqual(new Set(["path", "lodash"]));
+});
+
+it("skips files without carmi declaration comment", () => {
+  jest.resetModules();
+  const plugin = require("./index");
+  const original = `
+    const {root} = require('carmi')
+    const {resolve} = require('path')
+    const _ = require('lodash')
+    module.exports = {first: root.get(0)}
+  `;
+  const { code } = babel.transform(original, {
+    plugins: [plugin],
+    filename: resolve(__dirname, "test.carmi.js")
+  });
+  expect(formatCode(code)).toEqual(formatCode(original));
 });

--- a/src/babelPlugin/test.carmi.js
+++ b/src/babelPlugin/test.carmi.js
@@ -1,2 +1,4 @@
-const { root } = require('../../index');
-module.exports = { first: root.get(0), sum: root.call('sum') };
+// @carmi
+
+const { root } = require("../../index");
+module.exports = { first: root.get(0), sum: root.call("sum") };


### PR DESCRIPTION
Currently we compile everything that matches `*.carmi.js`, but sometimes we want to have
dependencies which use `carmi` as well, and we shouldn't make a "Model Builder" out of them
because it is unnecessary and slow.

*This is a breaking change to the Babel plugin!*

This will compile to a modelbuilder function:
```js
// file.carmi.js
// @carmi

... file contents ...
```

This won't:
```
// file.carmi.js

module.exports = { first: require('carmi').root.get(0) }
```

I removed the "carmi directive", because it is no longer needed (tests pass anyway) because I remove the `@carmi` magic comment on compilation