### PR TITLE
Drop *.mjs support so it would work on older node versions

### DIFF
--- a/bin/carmi
+++ b/bin/carmi
@@ -17,7 +17,7 @@ const optionDefinitions = [
   { name: 'format', type: String, defaultValue: 'iife', description: 'output format - iife,cjs...' },
   { name: 'name', type: String, defaultValue: 'model', description: 'name of the output module/function' },
   { name: 'minify', type: Boolean, defaultValue: false, description: 'minify output' },
-  { name: 'help', type: Boolean, defaultValue: false },
+  { name: 'help', type: Boolean, defaultValue: false, description: 'shows this very help message and quits' },
   { name: 'ast', type: Boolean, defaultValue: false }
 ];
 
@@ -36,12 +36,7 @@ async function run() {
   let model;
   const absPath = path.resolve(process.cwd(), options.source);
   try {
-    if (path.extname(options.source) === '.mjs') {
-      model = await import(absPath);
-      model = model.default;
-    } else {
-      model = require(absPath);
-    }
+    model = require(absPath);
   } catch (e) {
     console.error(`failed to require ${options.source} ${e.stack}`);
     throw e;

--- a/bin/carmi.spec.js
+++ b/bin/carmi.spec.js
@@ -1,0 +1,27 @@
+const pify = require("pify");
+const { exec } = require("child_process");
+const path = require("path");
+const asyncExec = pify(exec);
+const BINARY_PATH = path.resolve(__dirname, "carmi");
+
+const runBinary = args => asyncExec(`${BINARY_PATH} ${args}`);
+
+describe("carmi binary", () => {
+  it("has a help menu", async () => {
+    const helpMessage = await runBinary("--help");
+    expect(helpMessage).toMatch(/shows this very help message/);
+  });
+
+  it("compiles a carmi file", async () => {
+    const filePath = path.resolve(
+      __dirname,
+      "..",
+      "src",
+      "babelPlugin",
+      "test.carmi.js"
+    );
+    const file = await runBinary(`--source ${filePath}`);
+    eval(file);
+    expect(typeof model).toBe("function");
+  });
+});


### PR DESCRIPTION
* Dropping `*.mjs` file support so it would work on Node 8 as well.
* I've added a test for making sure the binary works