### PR TITLE
exit with code=1 on unhandled promise rejection

### DIFF
--- a/bin/carmi
+++ b/bin/carmi
@@ -60,4 +60,4 @@ async function run() {
   }
 }
 
-run();
+run().catch(e => process.exit(1));

--- a/bin/carmi.spec.js
+++ b/bin/carmi.spec.js
@@ -4,6 +4,7 @@ const path = require("path");
 const { existsSync } = require("fs");
 const { readFile } = require("../src/promise-fs");
 const { file: tmpFile } = require("tmp-promise");
+const invert = require('invert-promise');
 
 const runBinary = args => exec(`${BINARY_PATH} ${args}`);
 
@@ -39,5 +40,13 @@ describe("carmi binary", () => {
     } finally {
       cleanup();
     }
+  });
+
+  it('exits with exit code 1 in case carmi fails', async () => {
+    const error = await invert(runBinary(
+      `--source dummy.js --output irrelevant --format cjs`
+    ));
+
+    expect(error.code).toBe(1);
   });
 });

--- a/package.json
+++ b/package.json
@@ -10,7 +10,16 @@
   "bin": {
     "carmi": "./bin/carmi"
   },
-  "files": ["bin", "src", "typings", "babel.js", "index.js", "jsx.js", "loader.js", "macro.js"],
+  "files": [
+    "bin",
+    "src",
+    "typings",
+    "babel.js",
+    "index.js",
+    "jsx.js",
+    "loader.js",
+    "macro.js"
+  ],
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },
@@ -38,6 +47,7 @@
   },
   "devDependencies": {
     "babel-plugin-tester": "^5.5.1",
+    "invert-promise": "^1.0.1",
     "jest": "^21.2.1",
     "mobx": "^5.0.2",
     "random-seed": "^0.3.0",


### PR DESCRIPTION
@avi please - noticed when I tried to import a path (in a carmi file) that does not exist and the executable exited with exit code = 0.