### PR TITLE
Added sugar for Object.assignIn([...])

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,13 +12,6 @@ const {
   WrappedPrimitive
 } = require('./src/lang');
 
-const sugar = require('./src/sugar');
-Object.keys(sugar).forEach(key => {
-  if (TokenTypeData[key]) {
-    throw new Error(`There is a builtin token with this sugar name ${key}`);
-  }
-});
-
 const compilerTypes = {};
 compilerTypes.naive = require('./src/naive-compiler');
 compilerTypes.simple = require('./src/simple-compiler');
@@ -134,6 +127,14 @@ function throwOnTokensFromOtherFuncs(expr, tag) {
 }
 
 const chain = val => wrap(convertArrayAndObjectsToExpr(val));
+
+const sugar = require('./src/sugar')(chain);
+Object.keys(sugar).forEach(key => {
+  if (TokenTypeData[key]) {
+    throw new Error(`There is a builtin token with this sugar name ${key}`);
+  }
+});
+
 
 proxyHandler.get = (target, key) => {
   const tokenData = TokenTypeData[key];

--- a/src/__tests__/objects.js
+++ b/src/__tests__/objects.js
@@ -264,5 +264,17 @@ describe('testing objects', () => {
       expect(inst.defined).toEqual(1);
       expect(inst.notDefined).not.toBeDefined();
     });
+    it('assignIn', async () => {
+      const model = {
+        defined: root.assignIn([{a: 'women'}]),
+        notDefined: root.assignIn([{x: 'men'}])
+      };
+      const optModel = eval(await compile(model, { compiler }));
+      const initialData = { a: { b: 1 } };
+
+      const inst = optModel(initialData);
+      expect(inst.defined.a).toEqual('women');
+      expect(inst.notDefined.x).toEqual('men');
+    });
   });
 });

--- a/src/sugar.js
+++ b/src/sugar.js
@@ -1,13 +1,23 @@
 const _ = require('lodash');
 
-function getIn(obj, path) {
-    return _.reduce(path, (acc, val) => {
-      return acc.ternary(acc.get(val), acc)
-    }, obj);
-}
+module.exports = function(chain) {
+    function getIn(obj, path) {
+        return _.reduce(path, (acc, val) => {
+            return acc.ternary(acc.get(val), acc)
+        }, obj);
+    }
 
-function includes(collection, val) {
-  return collection.anyValues(item => item.eq(val));
-}
+    function includes(collection, val) {
+        return collection.anyValues(item => item.eq(val));
+    }
 
-module.exports = { getIn, includes };
+    function assignIn(obj, args) {
+        return chain([
+            obj,
+            ...args
+        ]).assign();
+    }
+
+  return { getIn, includes, assignIn };
+};
+


### PR DESCRIPTION
Since `assign` is colliding with `Array.assign` I opted to implementing another one, sticking to Lodash's API, though I'd rather have a simple `Object.assign` 😝 