### PR TITLE
add support for String.split(String)

### DIFF
--- a/src/__tests__/strings.js
+++ b/src/__tests__/strings.js
@@ -34,5 +34,12 @@ describe('testing string functions', () => {
     testStringFunction('abcde', 'substring', [1, 3], 'bc')
     testStringFunction('abcde', 'toUpperCase', [], 'ABCDE')
     testStringFunction('abcDE', 'toLowerCase', [], 'abcde')
+
+    describe('String.split', () => {
+      testStringFunction('ab/cd/e', 'split', ['/'], ['ab','cd','e'])
+      testStringFunction('ab', 'split', ['/'], ['ab'])
+      //String.split(RegExp) does not work yet:
+      //testStringFunction('abfoobar', 'split', [/foo/], ['ab', 'bar'])
+    })
   })
 })

--- a/src/lang.js
+++ b/src/lang.js
@@ -101,6 +101,7 @@ const TokenTypeData = {
   toUpperCase: new TokenTypes({nonChained: true, chainIndex: 1, len: [2, 2]}),
   toLowerCase: new TokenTypes({nonChained: true, chainIndex: 1, len: [2, 2]}),
   substring: new TokenTypes({nonChained: true, chainIndex: 1, len: [4, 4]}),
+  split: new TokenTypes({nonChained: true, chainIndex: 1, len: [3, 3]}),
   wildcard: new TokenTypes({ nonVerb: true, private: true })
 };
 

--- a/src/naive-compiler.js
+++ b/src/naive-compiler.js
@@ -16,7 +16,7 @@ const nativeOps = {
   mod: '%'
 };
 
-const nativeFunctions = ['startsWith', 'endsWith', 'toUpperCase', 'toLowerCase', 'substring'].map(name => ({[name]: `String.prototype.${name}`})).reduce(_.assign)
+const nativeFunctions = ['startsWith', 'endsWith', 'toUpperCase', 'toLowerCase', 'substring', 'split'].map(name => ({[name]: `String.prototype.${name}`})).reduce(_.assign)
 class NaiveCompiler {
   constructor(model, options) {
     const { getters, setters } = splitSettersGetters(model);
@@ -96,6 +96,7 @@ class NaiveCompiler {
         return `(${this.generateExpr(expr[1])}) ${nativeOps[tokenType]} (${this.generateExpr(expr[2])})`;
       case 'startsWith':
       case 'endsWith':
+      case 'split':
         return `(${nativeFunctions[tokenType]}).call(${this.generateExpr(expr[1])}, ${this.generateExpr(expr[2])})`;
       case 'substring':
         return `(${nativeFunctions[tokenType]}).call(${this.generateExpr(expr[1])}, ${this.generateExpr(expr[2])}, ${this.generateExpr(expr[3])})`;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -26,6 +26,7 @@ declare namespace carmi {
     startsWith(s: StringArgument): BoolExpression
     endsWith(s: StringArgument): BoolExpression
     plus(num: StringArgument): StringExpression
+    split(s: StringArgument): ArrayExpression<StringExpression>
     toUpperCase(): StringExpression
     toLowerCase(): StringExpression
   }
@@ -47,7 +48,7 @@ declare namespace carmi {
   interface ObjectOrArrayExpression<ValueType extends Expression, ExampleModelType> extends Expression {
     get<IndexType extends keyof ExampleModelType>(index: IndexType): asExpression<ExampleModelType[IndexType]>
     // TODO: deep resolving of getIn
-    getIn<FirstArgType extends keyof ExampleModelType, NextArgTypes extends keyof ExampleModelType>(path: [FirstArgType, ...(NextArgTypes[])]) : 
+    getIn<FirstArgType extends keyof ExampleModelType, NextArgTypes extends keyof ExampleModelType>(path: [FirstArgType, ...(NextArgTypes[])]) :
       GetterOrSetterExpression
     size(): NumberExpression
   }


### PR DESCRIPTION
Regular expressions is more complex.
It looks like carmi doesn't know what to do to invalidate the cache.
I tried to resolve it but after ~20 min gave up - can come back to handle RegExp if there's a use case for it