### PR TITLE
Config Webpack loader to add user modules as loader dependencies

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -7,7 +7,6 @@ const {compile} = require('carmi');
 const esm = require('esm');
 
 module.exports = function CarmiLoader() {
-  this.cacheable(false);
   const callback = this.async();
   const srcPath = this.getDependencies()[0];
   const requiredPreCarmi = new Set(Object.keys(require.cache));


### PR DESCRIPTION
### Summary

This PR configures the Webpack loader to be cachable and make it work with Webpack's watcher. It adds user modules as loader dependencies ([see here](https://webpack.js.org/contribute/writing-a-loader/#loader-dependencies)) so Webpack can purge cache and watch them.

I used `require.cache` to determine what all user modules are but we can change it to something different (static analysis?) in the future.

I didn't find any tests for the Webpack loader so I didn't add a test for this use case.
