### PR TITLE
Replace Rollup with a switch case and remove the option to minify with UglifyJs

### DIFF
--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -33,7 +33,6 @@ async function precompileModel(testname, type) {
     compiler: type,
     format: 'cjs',
     name: testname,
-    minify: false
   });
   fs.writeFileSync(resolveTestName(testname, type) + '.js', src);
 }

--- a/bin/carmi
+++ b/bin/carmi
@@ -19,7 +19,6 @@ const optionDefinitions = [
   { name: 'format', type: String, defaultValue: 'iife', description: 'output format - iife,cjs...' },
   { name: 'name', type: String, defaultValue: 'model', description: 'name of the output module/function' },
   { name: 'prettier', type: Boolean, defaultValue: false, description: 'run prettier on the output' },
-  { name: 'minify', type: Boolean, defaultValue: false, description: 'minify output' },
   {
     name: 'cache',
     type: String,

--- a/index.js
+++ b/index.js
@@ -316,7 +316,9 @@ async function compile(model, options) {
   } else {
     result = source;
   }
-
+  if (hashFile) {
+    require('fs').writeFileSync(hashFile, result);
+  }
   return result;
 }
 

--- a/package.json
+++ b/package.json
@@ -40,9 +40,6 @@
     "object-hash": "^1.3.0",
     "pify": "^4.0.1",
     "prettier": "^1.13.5",
-    "rollup": "^0.59.1",
-    "rollup-plugin-uglify": "^3.0.0",
-    "rollup-plugin-virtual": "^1.0.1",
     "toposort": "^1.0.6",
     "typescript": "^3.2.1"
   },

--- a/src/babelPlugin/__snapshots__/macro.spec.js.snap
+++ b/src/babelPlugin/__snapshots__/macro.spec.js.snap
@@ -12,10 +12,49 @@ module.exports = {todosList};
       ↓ ↓ ↓ ↓ ↓ ↓
 
 module.exports = function () {
-  'use strict';
-  function model($model, $funcLib, $batchingStrategy) {
-    const $res = { $model };
-    const $listeners = new Set();const $trackingMap = new WeakMap();const $trackedMap = new WeakMap();const $trackingWildcards = new WeakMap();const $invalidatedMap = new WeakMap();const $invalidatedRoots = new Set();$invalidatedRoots.$subKeys = {};$invalidatedRoots.$parentKey = null;$invalidatedRoots.$parent = null;let $first = true;let $tainted = new WeakSet();$invalidatedMap.set($res, $invalidatedRoots);const untrack = ($targetKeySet, $targetKey) => {
+  return function model($model, $funcLib, $batchingStrategy) {
+    'use strict';
+    const $res = { $model };const $listeners = new Set();const $trackingMap = new WeakMap();const $trackedMap = new WeakMap();const $trackingWildcards = new WeakMap();const $invalidatedMap = new WeakMap();const $invalidatedRoots = new Set();$invalidatedRoots.$subKeys = {};$invalidatedRoots.$parentKey = null;$invalidatedRoots.$parent = null;let $first = true;let $tainted = new WeakSet();$invalidatedMap.set($res, $invalidatedRoots);const $uniquePersistentObjects = new Map();const getUniquePersistenObject = id => {
+      if (!$uniquePersistentObjects.has(id)) {
+        $uniquePersistentObjects.set(id, {});
+      }return $uniquePersistentObjects.get(id);
+    };const collectAllItems = (res, obj, prefix) => {
+      if (typeof obj !== 'object') {
+        return;
+      }res.set(obj, prefix);const keys = Array.isArray(obj) ? new Array(obj.length).fill().map((_, idx) => idx) : Object.keys(obj);keys.forEach(idx => {
+        const child = obj[idx];if (typeof child === 'object') {
+          collectAllItems(res, child, \`\${prefix}.\${idx}\`);
+        }
+      });
+    };const serialize = (all, obj) => {
+      if (all.has(obj)) {
+        return all.get(obj);
+      } else if (obj instanceof WeakMap) {
+        return Array.from(all.keys()).reduce((acc, item) => {
+          if (obj.has(item)) {
+            acc[all.get(item)] = serialize(all, obj.get(item));
+          }return acc;
+        }, {});
+      } else if (obj instanceof Map) {
+        return Array.from(obj.keys()).reduce((acc, item) => {
+          if (all.has(item)) {
+            acc[all.get(item)] = serialize(all, obj.get(item));
+          } else {
+            acc[item] = serialize(all, obj.get(item));
+          }return acc;
+        }, {});
+      } else if (obj instanceof Set || obj instanceof Array) {
+        return Array.from(obj).map(x => all.has(x) ? all.get(x) : serialize(all, x));
+      } else if (typeof obj === 'object') {
+        return Object.keys(obj).reduce((acc, key) => {
+          acc[key] = serialize(all, obj[key]);return acc;
+        }, {});
+      } else {
+        return obj;
+      }
+    };const debug = () => {
+      const all = new Map();collectAllItems(all, $model, '$model');collectAllItems(all, $res, '$res');console.log(\`Found \${all.size} records\`);console.log(JSON.stringify(serialize(all, { $trackingMap, $invalidatedMap }), null, 2));
+    };const untrack = ($targetKeySet, $targetKey) => {
       const $tracked = $trackedMap.get($targetKeySet);if (!$tracked || !$tracked[$targetKey]) {
         return;
       }$tracked[$targetKey].forEach(({ $sourceObj, $sourceKey, $target }) => {
@@ -35,6 +74,14 @@ module.exports = function () {
           $changed = true;triggerInvalidations($target, $key, $hard);
         }
       }$target[$key] = $val;return $changed;
+    }function deleteOnObject($target, $key, $invalidates) {
+      let $hard = false;if ($invalidates) {
+        if (typeof $target[$key] === 'object' && $target[$key]) {
+          $hard = true;
+        }triggerInvalidations($target, $key, $hard);
+      }const $invalidatedKeys = $invalidatedMap.get($target);if ($invalidatedKeys) {
+        delete $invalidatedKeys.$subKeys[$key];
+      }delete $target[$key];
     }function setOnArray($target, $key, $val, $invalidates) {
       let $hard = false;if ($invalidates && !$first) {
         if (typeof $target[$key] === 'object' && $target[$key] && $target[$key] !== $val) {
@@ -43,6 +90,16 @@ module.exports = function () {
           triggerInvalidations($target, $key, $hard);
         }
       }$target[$key] = $val;
+    }function track($target, $sourceObj, $sourceKey, $soft) {
+      if (!$trackingMap.has($sourceObj)) {
+        $trackingMap.set($sourceObj, {});
+      }const $track = $trackingMap.get($sourceObj);$track[$sourceKey] = $track[$sourceKey] || new Map();$track[$sourceKey].set($target, $soft);const $tracked = $trackedMap.get($target[0]);$tracked[$target[1]] = $tracked[$target[1]] || [];$tracked[$target[1]].push({ $sourceKey, $sourceObj, $target });
+    }function trackPath($target, $path) {
+      if (!$trackedMap.has($target[0])) {
+        $trackedMap.set($target[0], {});
+      }const $end = $path.length - 2;let $current = $path[0];for (let i = 0; i <= $end; i++) {
+        track($target, $current, $path[i + 1], i !== $end);$current = $current[$path[i + 1]];
+      }
     }function triggerInvalidations($sourceObj, $sourceKey, $hard) {
       $tainted.add($sourceObj);const $track = $trackingMap.get($sourceObj);if ($track && $track.hasOwnProperty($sourceKey)) {
         $track[$sourceKey].forEach(($soft, $target) => {
@@ -55,13 +112,284 @@ module.exports = function () {
           invalidate($targetInvalidatedKeys, $sourceKey);
         });
       }
+    }function initOutput($parentInvalidatedKeys, $targetKey, src, func, createDefaultValue, createCacheValue) {
+      const subKeys = $parentInvalidatedKeys.$subKeys;const $cachePerTargetKey = subKeys[$targetKey] = subKeys[$targetKey] || new Map();let $cachedByFunc = $cachePerTargetKey.get(func);if (!$cachedByFunc) {
+        const $resultObj = createDefaultValue();const $cacheValue = createCacheValue();const $invalidatedKeys = new Set();$invalidatedKeys.$subKeys = {};$invalidatedKeys.$parentKey = $targetKey;$invalidatedKeys.$parent = $parentInvalidatedKeys;$invalidatedMap.set($resultObj, $invalidatedKeys);$cachedByFunc = [null, $resultObj, $invalidatedKeys, true, $cacheValue];$cachePerTargetKey.set(func, $cachedByFunc);
+      } else {
+        $cachedByFunc[3] = false;
+      }const $invalidatedKeys = $cachedByFunc[2];const $prevSrc = $cachedByFunc[0];if ($prevSrc !== src) {
+        if ($prevSrc) {
+          // prev mapped to a different collection
+          $trackingWildcards.get($prevSrc).delete($invalidatedKeys);if (Array.isArray($prevSrc)) {
+            $prevSrc.forEach((_item, index) => $invalidatedKeys.add(index));
+          } else {
+            Object.keys($prevSrc).forEach(key => $invalidatedKeys.add(key));
+          }if (Array.isArray(src)) {
+            src.forEach((_item, index) => $invalidatedKeys.add(index));
+          } else {
+            Object.keys(src).forEach(key => $invalidatedKeys.add(key));
+          }
+        }if (!$trackingWildcards.has(src)) {
+          $trackingWildcards.set(src, new Set());
+        }$trackingWildcards.get(src).add($invalidatedKeys);$cachedByFunc[0] = src;
+      }return $cachedByFunc;
+    }const emptyObj = () => {
+      return {};
+    };const emptyArr = () => [];const nullFunc = () => null;function mapValuesOpt($targetObj, $targetKey, identifier, func, src, context, $invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyObj, nullFunc);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];($new && Object.keys(src) || $invalidatedKeys).forEach(key => {
+        if (!src.hasOwnProperty(key)) {
+          if ($out.hasOwnProperty(key)) {
+            deleteOnObject($out, key, $invalidates);
+          }
+        } else {
+          const res = func($invalidatedKeys, key, src[key], context);setOnObject($out, key, res, $invalidates);
+        }
+      });$invalidatedKeys.clear();return $out;
+    }function filterByOpt($targetObj, $targetKey, identifier, func, src, context, $invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyObj, nullFunc);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];($new && Object.keys(src) || $invalidatedKeys).forEach(key => {
+        if (!src.hasOwnProperty(key)) {
+          if ($out.hasOwnProperty(key)) {
+            deleteOnObject($out, key, $invalidates);
+          }
+        } else {
+          const res = func($invalidatedKeys, key, src[key], context);if (res) {
+            setOnObject($out, key, src[key], $invalidates);
+          } else if ($out.hasOwnProperty(key)) {
+            deleteOnObject($out, key, $invalidates);
+          }
+        }
+      });$invalidatedKeys.clear();return $out;
+    }function mapOpt($targetObj, $targetKey, identifier, func, src, context, $invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyArr, nullFunc);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];if ($new) {
+        for (let key = 0; key < src.length; key++) {
+          const res = func($invalidatedKeys, key, src[key], context);setOnArray($out, key, res, $invalidates);
+        }
+      } else {
+        $invalidatedKeys.forEach(key => {
+          if (key >= src.length) {
+            setOnArray($out, key, undefined, $invalidates);$out.length = src.length;
+          } else {
+            const res = func($invalidatedKeys, key, src[key], context);setOnArray($out, key, res, $invalidates);
+          }
+        });
+      }$invalidatedKeys.clear();return $out;
+    }function recursiveSteps(key, $localInvalidatedKeys, $localKey) {
+      const { $dependencyMap, $currentStack, $invalidatedKeys, $out, func, src, context, $invalidates } = this;if ($currentStack.length > 0) {
+        if (!$dependencyMap.has(key)) {
+          $dependencyMap.set(key, []);
+        }$dependencyMap.get(key).push({ $localInvalidatedKeys, $localKey });
+      }if ($invalidatedKeys.has(key)) {
+        $currentStack.push(key);if (Array.isArray($out)) {
+          if (key >= src.length) {
+            setOnArray($out, key, undefined, $invalidates);$out.length = src.length;
+          } else {
+            const newVal = func($invalidatedKeys, key, src[key], context, this);setOnArray($out, key, newVal, $invalidates);
+          }
+        } else {
+          if (!src.hasOwnProperty(key)) {
+            if ($out.hasOwnProperty(key)) {
+              deleteOnObject($out, key, $invalidates);
+            }
+          } else {
+            const newVal = func($invalidatedKeys, key, src[key], context, this);setOnObject($out, key, newVal, $invalidates);
+          }
+        }$invalidatedKeys.delete(key);$currentStack.pop();
+      }return $out[key];
+    }function cascadeRecursiveInvalidations($loop) {
+      const { $dependencyMap, $invalidatedKeys } = $loop;$invalidatedKeys.forEach(key => {
+        if ($dependencyMap.has(key)) {
+          $dependencyMap.get(key).forEach(({ $localInvalidatedKeys, $localKey }) => {
+            invalidate($localInvalidatedKeys, $localKey);
+          });$dependencyMap.delete(key);
+        }
+      });
+    }const recursiveCacheFunc = () => ({ $dependencyMap: new Map(), $currentStack: [], recursiveSteps });function recursiveMapOpt($targetObj, $targetKey, identifier, func, src, context, $invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyArr, recursiveCacheFunc);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];const $loop = $storage[4];$loop.$invalidatedKeys = $invalidatedKeys;$loop.$out = $out;$loop.context = context;$loop.func = func;$loop.src = src;$loop.$invalidates = $invalidates;if ($new) {
+        for (let key = 0; key < src.length; key++) {
+          $invalidatedKeys.add(key);
+        }for (let key = 0; key < src.length; key++) {
+          $loop.recursiveSteps(key, $invalidatedKeys, key);
+        }
+      } else {
+        cascadeRecursiveInvalidations($loop);$invalidatedKeys.forEach(key => {
+          $loop.recursiveSteps(key, $invalidatedKeys, key);
+        });
+      }$invalidatedKeys.clear();return $out;
+    }function recursiveMapValuesOpt($targetObj, $targetKey, identifier, func, src, context, $invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyObj, recursiveCacheFunc);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];const $loop = $storage[4];$loop.$invalidatedKeys = $invalidatedKeys;$loop.$out = $out;$loop.context = context;$loop.func = func;$loop.src = src;$loop.$invalidates = $invalidates;if ($new) {
+        Object.keys(src).forEach(key => $invalidatedKeys.add(key));Object.keys(src).forEach(key => $loop.recursiveSteps(key, $invalidatedKeys, key));
+      } else {
+        cascadeRecursiveInvalidations($loop);$invalidatedKeys.forEach(key => {
+          $loop.recursiveSteps(key, $invalidatedKeys, key);
+        });
+      }$invalidatedKeys.clear();return $out;
+    }function keyByOpt($targetObj, $targetKey, identifier, func, src, context, $invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyObj, emptyArr);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];const $idxToKey = $storage[4];if ($new) {
+        for (let key = 0; key < src.length; key++) {
+          const newKey = '' + func($invalidatedKeys, key, src[key], context);$idxToKey[key] = newKey;setOnObject($out, newKey, src[key], $invalidates);
+        }
+      } else {
+        const keysPendingDelete = new Set();$invalidatedKeys.forEach(key => keysPendingDelete.add($idxToKey[key]));$invalidatedKeys.forEach(key => {
+          if (key < src.length) {
+            const newKey = '' + func($invalidatedKeys, key, src[key], context);keysPendingDelete.delete(newKey);$idxToKey[key] = newKey;setOnObject($out, newKey, src[key], $invalidates);
+          }
+        });keysPendingDelete.forEach(key => {
+          triggerInvalidations($out, key, true);delete $out[key];
+        });
+      }$idxToKey.length = src.length;$invalidatedKeys.clear();return $out;
+    }function mapKeysOpt($targetObj, $targetKey, identifier, func, src, context, $invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyObj, emptyObj);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];const $keyToKey = $storage[4];if ($new) {
+        Object.keys(src).forEach(key => {
+          const newKey = func($invalidatedKeys, key, src[key], context);setOnObject($out, newKey, src[key], $invalidates);$keyToKey[key] = newKey;
+        });
+      } else {
+        const keysPendingDelete = new Set();$invalidatedKeys.forEach(key => {
+          if ($keyToKey.hasOwnProperty(key)) {
+            keysPendingDelete.add($keyToKey[key]);delete $keyToKey[key];
+          }
+        });$invalidatedKeys.forEach(key => {
+          if (src.hasOwnProperty(key)) {
+            const newKey = func($invalidatedKeys, key, src[key], context);setOnObject($out, newKey, src[key], $invalidates);$keyToKey[key] = newKey;keysPendingDelete.delete(newKey);
+          }
+        });keysPendingDelete.forEach(key => {
+          deleteOnObject($out, key, $invalidates);
+        });
+      }$invalidatedKeys.clear();return $out;
+    }const filterCacheFunc = () => [0];function filterOpt($targetObj, $targetKey, identifier, func, src, context, $invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyArr, filterCacheFunc);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];const $idxToIdx = $storage[4];if ($new) {
+        for (let key = 0; key < src.length; key++) {
+          const passed = !!func($invalidatedKeys, key, src[key], context);const prevItemIdx = $idxToIdx[key];const nextItemIdx = passed ? prevItemIdx + 1 : prevItemIdx;$idxToIdx[key + 1] = nextItemIdx;if (nextItemIdx !== prevItemIdx) {
+            setOnArray($out, prevItemIdx, src[key], $invalidates);
+          }
+        }
+      } else {
+        let firstIndex = Number.MAX_SAFE_INTEGER;$invalidatedKeys.forEach(key => firstIndex = Math.min(firstIndex, key));for (let key = firstIndex; key < src.length; key++) {
+          const passed = !!func($invalidatedKeys, key, src[key], context);const prevItemIdx = $idxToIdx[key];const nextItemIdx = passed ? prevItemIdx + 1 : prevItemIdx;$idxToIdx[key + 1] = nextItemIdx;if (nextItemIdx !== prevItemIdx) {
+            setOnArray($out, prevItemIdx, src[key], $invalidates);
+          }
+        }$idxToIdx.length = src.length + 1;for (let key = $idxToIdx[$idxToIdx.length - 1]; key < $out.length; key++) {
+          triggerInvalidations($out, key);
+        }$out.length = $idxToIdx[$idxToIdx.length - 1];
+      }$invalidatedKeys.clear();return $out;
+    }function anyOpt($targetObj, $targetKey, identifier, func, src, context, $invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyArr, nullFunc);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3]; // $out has at most 1 key - the one that stopped the previous run because it was truthy
+      if ($new) {
+        for (let key = 0; key < src.length; key++) {
+          $invalidatedKeys.add(key);
+        }
+      }const $prevStop = $out.length > 0 ? $out[0] : -1;if ($prevStop !== -1) {
+        if ($invalidatedKeys.has($prevStop)) {
+          $invalidatedKeys.delete($prevStop);const passedTest = func($invalidatedKeys, $prevStop, src[$prevStop], context);if (passedTest) {
+            return true;
+          } else {
+            $out.length = 0;
+          }
+        } else {
+          return true;
+        }
+      }for (let key of $invalidatedKeys) {
+        $invalidatedKeys.delete(key);if (func($invalidatedKeys, key, src[key], context)) {
+          $out[0] = key;return true;
+        }
+      }return false;
+    }function anyValuesOpt($targetObj, $targetKey, identifier, func, src, context, $invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyArr, nullFunc);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3]; // $out has at most 1 key - the one that stopped the previous run because it was truthy
+      if ($new) {
+        Object.keys(src).forEach(key => $invalidatedKeys.add(key));
+      }const $prevStop = $out.length > 0 ? $out[0] : -1;if ($prevStop !== -1) {
+        if ($invalidatedKeys.has($prevStop)) {
+          $invalidatedKeys.delete($prevStop);const passedTest = func($invalidatedKeys, $prevStop, src[$prevStop], context);if (passedTest) {
+            return true;
+          } else {
+            $out.length = 0;
+          }
+        } else {
+          return true;
+        }
+      }for (let key of $invalidatedKeys) {
+        $invalidatedKeys.delete(key);if (func($invalidatedKeys, key, src[key], context)) {
+          $out[0] = key;return true;
+        }
+      }return false;
+    }function groupByOpt($targetObj, $targetKey, identifier, func, src, context, $invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyObj, emptyObj);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];const $keyToKey = $storage[4];if (Array.isArray(src)) {
+        throw new Error('groupBy only works on objects');
+      }if ($new) {
+        Object.keys(src).forEach(key => {
+          const res = '' + func($invalidatedKeys, key, src[key], context);$keyToKey[key] = res;if (!$out[res]) {
+            setOnObject($out, res, {}, $invalidates);
+          }setOnObject($out[res], key, src[key], $invalidates);
+        });
+      } else {
+        const keysPendingDelete = {};$invalidatedKeys.forEach(key => {
+          if ($keyToKey[key]) {
+            keysPendingDelete[$keyToKey[key]] = keysPendingDelete[$keyToKey[key]] || new Set();keysPendingDelete[$keyToKey[key]].add(key);
+          }
+        });$invalidatedKeys.forEach(key => {
+          const res = '' + func($invalidatedKeys, key, src[key], context);$keyToKey[key] = res;if (!$out[res]) {
+            setOnObject($out, res, {}, $invalidates);
+          }setOnObject($out[res], key, src[key], $invalidates);if (keysPendingDelete.hasOwnProperty(res)) {
+            keysPendingDelete[res].delete(key);
+          }
+        });Object.keys(keysPendingDelete).forEach(res => {
+          if (keysPendingDelete[res].size > 0) {
+            keysPendingDelete[res].forEach(key => {
+              triggerInvalidations($out[res], key);delete $out[res][key];
+            });triggerInvalidations($out, res);if (Object.keys($out[res]).length == 0) {
+              delete $out[res];
+            }
+          }
+        });
+      }$invalidatedKeys.clear();return $out;
+    }const valuesOrKeysCacheFunc = () => ({ $keyToIdx: {}, $idxToKey: [] });function valuesOrKeysForObject($targetObj, $targetKey, identifier, src, getValues) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyArr, valuesOrKeysCacheFunc);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];const { $keyToIdx, $idxToKey } = $storage[4];if ($new) {
+        Object.keys(src).forEach((key, idx) => {
+          $out[idx] = getValues ? src[key] : key;$idxToKey[idx] = key;$keyToIdx[key] = idx;
+        });
+      } else {
+        const $deletedKeys = [];const $addedKeys = [];const $touchedKeys = [];$invalidatedKeys.forEach(key => {
+          if (src.hasOwnProperty(key) && !$keyToIdx.hasOwnProperty(key)) {
+            $addedKeys.push(key);
+          } else if (!src.hasOwnProperty(key) && $keyToIdx.hasOwnProperty(key)) {
+            $deletedKeys.push(key);
+          } else {
+            if ($keyToIdx.hasOwnProperty(key)) {
+              $out[$keyToIdx[key]] = getValues ? src[key] : key;triggerInvalidations($out, $keyToIdx[key]);
+            }
+          }
+        });if ($addedKeys.length < $deletedKeys.length) {
+          $deletedKeys.sort((a, b) => $keyToIdx[a] - $keyToIdx[b]);
+        }const $finalOutLength = $out.length - $deletedKeys.length + $addedKeys.length; // keys both deleted and added fill created holes first
+        for (let i = 0; i < $addedKeys.length && i < $deletedKeys.length; i++) {
+          const $addedKey = $addedKeys[i];const $deletedKey = $deletedKeys[i];const $newIdx = $keyToIdx[$deletedKey];delete $keyToIdx[$deletedKey];$keyToIdx[$addedKey] = $newIdx;$idxToKey[$newIdx] = $addedKey;$out[$newIdx] = getValues ? src[$addedKey] : $addedKey;triggerInvalidations($out, $newIdx);
+        } // more keys added - append to end
+        for (let i = $deletedKeys.length; i < $addedKeys.length; i++) {
+          const $addedKey = $addedKeys[i];const $newIdx = $out.length;$keyToIdx[$addedKey] = $newIdx;$idxToKey[$newIdx] = $addedKey;$out[$newIdx] = getValues ? src[$addedKey] : $addedKey;triggerInvalidations($out, $newIdx);
+        } // more keys deleted - move non deleted items at the tail to the location of deleted
+        const $deletedNotMoved = $deletedKeys.slice($addedKeys.length);const $deletedNotMovedSet = new Set($deletedKeys.slice($addedKeys.length));const $keysToMoveInside = new Set($idxToKey.slice($finalOutLength).filter(key => !$deletedNotMovedSet.has(key)));let $savedCount = 0;for (let $tailIdx = $finalOutLength; $tailIdx < $out.length; $tailIdx++) {
+          const $currentKey = $idxToKey[$tailIdx];if ($keysToMoveInside.has($currentKey)) {
+            // need to move this key to one of the pending delete
+            const $switchedWithDeletedKey = $deletedNotMoved[$savedCount];const $newIdx = $keyToIdx[$switchedWithDeletedKey];$out[$newIdx] = getValues ? src[$currentKey] : $currentKey;$keyToIdx[$currentKey] = $newIdx;$idxToKey[$newIdx] = $currentKey;delete $keyToIdx[$switchedWithDeletedKey];triggerInvalidations($out, $newIdx);$savedCount++;
+          } else {
+            delete $keyToIdx[$currentKey];
+          }triggerInvalidations($out, $tailIdx);
+        }$out.length = $finalOutLength;$idxToKey.length = $out.length;$invalidatedKeys.clear();
+      }return $out;
     }function getEmptyArray($invalidatedKeys, $targetKey, token) {
       const subKeys = $invalidatedKeys.$subKeys;const $cachePerTargetKey = subKeys[$targetKey] = subKeys[$targetKey] || new Map();if (!$cachePerTargetKey.has(token)) {
         $cachePerTargetKey.set(token, []);
       }return $cachePerTargetKey.get(token);
+    }function getEmptyObject($invalidatedKeys, $targetKey, token) {
+      const subKeys = $invalidatedKeys.$subKeys;const $cachePerTargetKey = subKeys[$targetKey] = subKeys[$targetKey] || new Map();if (!$cachePerTargetKey.has(token)) {
+        $cachePerTargetKey.set(token, {});
+      }return $cachePerTargetKey.get(token);
     }function array($invalidatedKeys, key, newVal, identifier, len, invalidates) {
       const res = getEmptyArray($invalidatedKeys, key, identifier);invalidates = invalidates && res.length === len;for (let i = 0; i < len; i++) {
         setOnArray(res, i, newVal[i], invalidates);
+      }return res;
+    }function object($invalidatedKeys, key, newVal, identifier, keysList, invalidates) {
+      const res = getEmptyObject($invalidatedKeys, key, identifier);invalidates = invalidates && keysList.length && res.hasOwnProperty(keysList[0]);for (let i = 0; i < keysList.length; i++) {
+        const name = keysList[i];setOnObject(res, name, newVal[name], invalidates);
       }return res;
     }function call($invalidatedKeys, key, newVal, identifier, len, invalidates) {
       const arr = getEmptyArray($invalidatedKeys, key, identifier);if (arr.length === 0) {
@@ -71,15 +399,67 @@ module.exports = function () {
       }if (arr.length === 1 || $tainted.has(args)) {
         arr[1] = $funcLib[args[0]].apply($res, args.slice(1));
       }return arr[1];
+    }function bind($invalidatedKeys, key, newVal, identifier, len) {
+      const arr = getEmptyArray($invalidatedKeys, key, identifier);if (arr.length === 0) {
+        arr.push([]);
+      }const args = arr[0];for (let i = 0; i < len; i++) {
+        args[i] = newVal[i];
+      }if (arr.length === 1) {
+        arr[1] = (...extraArgs) => {
+          const fn = $funcLib[args[0]] || $res[args[0]];return fn.apply($res, args.slice(1).concat(extraArgs));
+        };
+      }return arr[1];
+    }function assignOrDefaults($targetObj, $targetKey, identifier, src, assign, invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyObj, nullFunc);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];if (!assign) {
+        src = [...src].reverse();
+      }if ($new) {
+        Object.assign($out, ...src);
+      } else {
+        const $keysPendingDelete = new Set(Object.keys($out));const res = Object.assign({}, ...src);Object.keys(res).forEach(key => {
+          $keysPendingDelete.delete(key);setOnObject($out, key, res[key], invalidates);
+        });$keysPendingDelete.forEach(key => {
+          delete $out[key];triggerInvalidations($out, key);
+        });$invalidatedKeys.clear();
+      }return $out;
+    }function size($targetObj, $targetKey, src, identifier) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyArr, nullFunc);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];if ($new) {
+        $out[0] = Array.isArray(src) ? src.length : Object.keys(src).length;
+      }if (!$new) {
+        $out[0] = Array.isArray(src) ? src.length : Object.keys(src).length;$invalidatedKeys.clear();
+      }return $out[0];
+    }function range($invalidatedKeys, key, end, start, step, identifier) {
+      const $out = getEmptyArray($invalidatedKeys, key, identifier);if ($out.length === 0) {
+        for (let val = start; step > 0 && val < end || step < 0 && val > end; val += step) {
+          $out.push(val);
+        }
+      } else {
+        let len = 0;for (let val = start; step > 0 && val < end || step < 0 && val > end; val += step) {
+          if ($out[len] !== val) {
+            triggerInvalidations($out, len);
+          }$out[len] = val;len++;
+        }if ($out.length > len) {
+          for (let i = len; i < $out.length; i++) {
+            triggerInvalidations($out, i);
+          }$out.length = len;
+        }
+      }return $out;
     }$invalidatedRoots.add('todosList');function $todosListBuild() {
-      const key = 'todosList';const $invalidatedKeys = $invalidatedRoots;const newValue = call($invalidatedKeys, key, [\\"createElement\\", $res[\\"$array_temp_4_19_1\\"]], '4', 2, false);setOnObject($res, 'todosList', newValue, false);$invalidatedRoots.delete('todosList');return $res.todosList;
+      const acc = $res;const key = 'todosList';const $invalidatedKeys = $invalidatedRoots;const newValue = call($invalidatedKeys, key, [\\"createElement\\", $res[\\"$array_temp_4_19_1\\"]], '4', 2, false);setOnObject($res, 'todosList', newValue, false);$invalidatedRoots.delete('todosList');return $res.todosList;
     }$invalidatedRoots.add('$array_temp_4_19_1');function $array_temp_4_19_1Build() {
-      const key = '$array_temp_4_19_1';const $invalidatedKeys = $invalidatedRoots;const newValue = array($invalidatedKeys, key, [\\"div\\", null, $model[0]], '2', 3, false);setOnObject($res, '$array_temp_4_19_1', newValue, false);$invalidatedRoots.delete('$array_temp_4_19_1');return $res.$array_temp_4_19_1;
-    }let $inBatch = false;let $batchPending = [];function recalculate() {
+      const acc = $res;const key = '$array_temp_4_19_1';const $invalidatedKeys = $invalidatedRoots;const newValue = array($invalidatedKeys, key, [\\"div\\", null, $model[0]], '2', 3, false);setOnObject($res, '$array_temp_4_19_1', newValue, false);$invalidatedRoots.delete('$array_temp_4_19_1');return $res.$array_temp_4_19_1;
+    }let $inBatch = false;let $batchPending = [];let $inRecalculate = false;function recalculate() {
       if ($inBatch) {
         return;
-      }$invalidatedRoots.has('$array_temp_4_19_1') && $array_temp_4_19_1Build();$invalidatedRoots.has('todosList') && $todosListBuild();$tainted = new WeakSet();$first = false;$listeners.forEach(callback => callback());if ($batchPending.length) {
+      }$inRecalculate = true;$invalidatedRoots.has('$array_temp_4_19_1') && $array_temp_4_19_1Build();$invalidatedRoots.has('todosList') && $todosListBuild();$tainted = new WeakSet();$first = false;$listeners.forEach(callback => callback());$inRecalculate = false;if ($batchPending.length) {
         $res.$endBatch();
+      }
+    }function $setter(func, ...args) {
+      if (!$inBatch && $batchingStrategy) {
+        $batchingStrategy.call($res);$inBatch = true;
+      }if ($inBatch || $inRecalculate) {
+        $batchPending.push({ func, args });
+      } else {
+        func.apply($res, args);recalculate();
       }
     }Object.assign($res, {}, { $startBatch: () => $inBatch = true, $endBatch: () => {
         $inBatch = false;if ($batchPending.length) {
@@ -94,7 +474,7 @@ module.exports = function () {
       }, $removeListener: func => {
         $listeners.delete(func);
       } });recalculate();return $res;
-  }return model;
+  };
 }();
 "
 `;
@@ -109,9 +489,49 @@ module.exports = { first: root.get(0), second: root.get(1) };
       ↓ ↓ ↓ ↓ ↓ ↓
 
 module.exports = function () {
-  'use strict';
-  function model($model, $funcLib, $batchingStrategy) {
-    const $res = { $model };const $listeners = new Set();const $trackingMap = new WeakMap();const $trackedMap = new WeakMap();const $trackingWildcards = new WeakMap();const $invalidatedMap = new WeakMap();const $invalidatedRoots = new Set();$invalidatedRoots.$subKeys = {};$invalidatedRoots.$parentKey = null;$invalidatedRoots.$parent = null;let $first = true;let $tainted = new WeakSet();$invalidatedMap.set($res, $invalidatedRoots);const untrack = ($targetKeySet, $targetKey) => {
+  return function model($model, $funcLib, $batchingStrategy) {
+    'use strict';
+    const $res = { $model };const $listeners = new Set();const $trackingMap = new WeakMap();const $trackedMap = new WeakMap();const $trackingWildcards = new WeakMap();const $invalidatedMap = new WeakMap();const $invalidatedRoots = new Set();$invalidatedRoots.$subKeys = {};$invalidatedRoots.$parentKey = null;$invalidatedRoots.$parent = null;let $first = true;let $tainted = new WeakSet();$invalidatedMap.set($res, $invalidatedRoots);const $uniquePersistentObjects = new Map();const getUniquePersistenObject = id => {
+      if (!$uniquePersistentObjects.has(id)) {
+        $uniquePersistentObjects.set(id, {});
+      }return $uniquePersistentObjects.get(id);
+    };const collectAllItems = (res, obj, prefix) => {
+      if (typeof obj !== 'object') {
+        return;
+      }res.set(obj, prefix);const keys = Array.isArray(obj) ? new Array(obj.length).fill().map((_, idx) => idx) : Object.keys(obj);keys.forEach(idx => {
+        const child = obj[idx];if (typeof child === 'object') {
+          collectAllItems(res, child, \`\${prefix}.\${idx}\`);
+        }
+      });
+    };const serialize = (all, obj) => {
+      if (all.has(obj)) {
+        return all.get(obj);
+      } else if (obj instanceof WeakMap) {
+        return Array.from(all.keys()).reduce((acc, item) => {
+          if (obj.has(item)) {
+            acc[all.get(item)] = serialize(all, obj.get(item));
+          }return acc;
+        }, {});
+      } else if (obj instanceof Map) {
+        return Array.from(obj.keys()).reduce((acc, item) => {
+          if (all.has(item)) {
+            acc[all.get(item)] = serialize(all, obj.get(item));
+          } else {
+            acc[item] = serialize(all, obj.get(item));
+          }return acc;
+        }, {});
+      } else if (obj instanceof Set || obj instanceof Array) {
+        return Array.from(obj).map(x => all.has(x) ? all.get(x) : serialize(all, x));
+      } else if (typeof obj === 'object') {
+        return Object.keys(obj).reduce((acc, key) => {
+          acc[key] = serialize(all, obj[key]);return acc;
+        }, {});
+      } else {
+        return obj;
+      }
+    };const debug = () => {
+      const all = new Map();collectAllItems(all, $model, '$model');collectAllItems(all, $res, '$res');console.log(\`Found \${all.size} records\`);console.log(JSON.stringify(serialize(all, { $trackingMap, $invalidatedMap }), null, 2));
+    };const untrack = ($targetKeySet, $targetKey) => {
       const $tracked = $trackedMap.get($targetKeySet);if (!$tracked || !$tracked[$targetKey]) {
         return;
       }$tracked[$targetKey].forEach(({ $sourceObj, $sourceKey, $target }) => {
@@ -131,6 +551,32 @@ module.exports = function () {
           $changed = true;triggerInvalidations($target, $key, $hard);
         }
       }$target[$key] = $val;return $changed;
+    }function deleteOnObject($target, $key, $invalidates) {
+      let $hard = false;if ($invalidates) {
+        if (typeof $target[$key] === 'object' && $target[$key]) {
+          $hard = true;
+        }triggerInvalidations($target, $key, $hard);
+      }const $invalidatedKeys = $invalidatedMap.get($target);if ($invalidatedKeys) {
+        delete $invalidatedKeys.$subKeys[$key];
+      }delete $target[$key];
+    }function setOnArray($target, $key, $val, $invalidates) {
+      let $hard = false;if ($invalidates && !$first) {
+        if (typeof $target[$key] === 'object' && $target[$key] && $target[$key] !== $val) {
+          $hard = true;
+        }if ($hard || $target[$key] !== $val || typeof $target[$key] === 'object' && $tainted.has($val) || !$target.hasOwnProperty($key) && $target[$key] === undefined) {
+          triggerInvalidations($target, $key, $hard);
+        }
+      }$target[$key] = $val;
+    }function track($target, $sourceObj, $sourceKey, $soft) {
+      if (!$trackingMap.has($sourceObj)) {
+        $trackingMap.set($sourceObj, {});
+      }const $track = $trackingMap.get($sourceObj);$track[$sourceKey] = $track[$sourceKey] || new Map();$track[$sourceKey].set($target, $soft);const $tracked = $trackedMap.get($target[0]);$tracked[$target[1]] = $tracked[$target[1]] || [];$tracked[$target[1]].push({ $sourceKey, $sourceObj, $target });
+    }function trackPath($target, $path) {
+      if (!$trackedMap.has($target[0])) {
+        $trackedMap.set($target[0], {});
+      }const $end = $path.length - 2;let $current = $path[0];for (let i = 0; i <= $end; i++) {
+        track($target, $current, $path[i + 1], i !== $end);$current = $current[$path[i + 1]];
+      }
     }function triggerInvalidations($sourceObj, $sourceKey, $hard) {
       $tainted.add($sourceObj);const $track = $trackingMap.get($sourceObj);if ($track && $track.hasOwnProperty($sourceKey)) {
         $track[$sourceKey].forEach(($soft, $target) => {
@@ -143,15 +589,354 @@ module.exports = function () {
           invalidate($targetInvalidatedKeys, $sourceKey);
         });
       }
+    }function initOutput($parentInvalidatedKeys, $targetKey, src, func, createDefaultValue, createCacheValue) {
+      const subKeys = $parentInvalidatedKeys.$subKeys;const $cachePerTargetKey = subKeys[$targetKey] = subKeys[$targetKey] || new Map();let $cachedByFunc = $cachePerTargetKey.get(func);if (!$cachedByFunc) {
+        const $resultObj = createDefaultValue();const $cacheValue = createCacheValue();const $invalidatedKeys = new Set();$invalidatedKeys.$subKeys = {};$invalidatedKeys.$parentKey = $targetKey;$invalidatedKeys.$parent = $parentInvalidatedKeys;$invalidatedMap.set($resultObj, $invalidatedKeys);$cachedByFunc = [null, $resultObj, $invalidatedKeys, true, $cacheValue];$cachePerTargetKey.set(func, $cachedByFunc);
+      } else {
+        $cachedByFunc[3] = false;
+      }const $invalidatedKeys = $cachedByFunc[2];const $prevSrc = $cachedByFunc[0];if ($prevSrc !== src) {
+        if ($prevSrc) {
+          // prev mapped to a different collection
+          $trackingWildcards.get($prevSrc).delete($invalidatedKeys);if (Array.isArray($prevSrc)) {
+            $prevSrc.forEach((_item, index) => $invalidatedKeys.add(index));
+          } else {
+            Object.keys($prevSrc).forEach(key => $invalidatedKeys.add(key));
+          }if (Array.isArray(src)) {
+            src.forEach((_item, index) => $invalidatedKeys.add(index));
+          } else {
+            Object.keys(src).forEach(key => $invalidatedKeys.add(key));
+          }
+        }if (!$trackingWildcards.has(src)) {
+          $trackingWildcards.set(src, new Set());
+        }$trackingWildcards.get(src).add($invalidatedKeys);$cachedByFunc[0] = src;
+      }return $cachedByFunc;
+    }const emptyObj = () => {
+      return {};
+    };const emptyArr = () => [];const nullFunc = () => null;function mapValuesOpt($targetObj, $targetKey, identifier, func, src, context, $invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyObj, nullFunc);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];($new && Object.keys(src) || $invalidatedKeys).forEach(key => {
+        if (!src.hasOwnProperty(key)) {
+          if ($out.hasOwnProperty(key)) {
+            deleteOnObject($out, key, $invalidates);
+          }
+        } else {
+          const res = func($invalidatedKeys, key, src[key], context);setOnObject($out, key, res, $invalidates);
+        }
+      });$invalidatedKeys.clear();return $out;
+    }function filterByOpt($targetObj, $targetKey, identifier, func, src, context, $invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyObj, nullFunc);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];($new && Object.keys(src) || $invalidatedKeys).forEach(key => {
+        if (!src.hasOwnProperty(key)) {
+          if ($out.hasOwnProperty(key)) {
+            deleteOnObject($out, key, $invalidates);
+          }
+        } else {
+          const res = func($invalidatedKeys, key, src[key], context);if (res) {
+            setOnObject($out, key, src[key], $invalidates);
+          } else if ($out.hasOwnProperty(key)) {
+            deleteOnObject($out, key, $invalidates);
+          }
+        }
+      });$invalidatedKeys.clear();return $out;
+    }function mapOpt($targetObj, $targetKey, identifier, func, src, context, $invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyArr, nullFunc);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];if ($new) {
+        for (let key = 0; key < src.length; key++) {
+          const res = func($invalidatedKeys, key, src[key], context);setOnArray($out, key, res, $invalidates);
+        }
+      } else {
+        $invalidatedKeys.forEach(key => {
+          if (key >= src.length) {
+            setOnArray($out, key, undefined, $invalidates);$out.length = src.length;
+          } else {
+            const res = func($invalidatedKeys, key, src[key], context);setOnArray($out, key, res, $invalidates);
+          }
+        });
+      }$invalidatedKeys.clear();return $out;
+    }function recursiveSteps(key, $localInvalidatedKeys, $localKey) {
+      const { $dependencyMap, $currentStack, $invalidatedKeys, $out, func, src, context, $invalidates } = this;if ($currentStack.length > 0) {
+        if (!$dependencyMap.has(key)) {
+          $dependencyMap.set(key, []);
+        }$dependencyMap.get(key).push({ $localInvalidatedKeys, $localKey });
+      }if ($invalidatedKeys.has(key)) {
+        $currentStack.push(key);if (Array.isArray($out)) {
+          if (key >= src.length) {
+            setOnArray($out, key, undefined, $invalidates);$out.length = src.length;
+          } else {
+            const newVal = func($invalidatedKeys, key, src[key], context, this);setOnArray($out, key, newVal, $invalidates);
+          }
+        } else {
+          if (!src.hasOwnProperty(key)) {
+            if ($out.hasOwnProperty(key)) {
+              deleteOnObject($out, key, $invalidates);
+            }
+          } else {
+            const newVal = func($invalidatedKeys, key, src[key], context, this);setOnObject($out, key, newVal, $invalidates);
+          }
+        }$invalidatedKeys.delete(key);$currentStack.pop();
+      }return $out[key];
+    }function cascadeRecursiveInvalidations($loop) {
+      const { $dependencyMap, $invalidatedKeys } = $loop;$invalidatedKeys.forEach(key => {
+        if ($dependencyMap.has(key)) {
+          $dependencyMap.get(key).forEach(({ $localInvalidatedKeys, $localKey }) => {
+            invalidate($localInvalidatedKeys, $localKey);
+          });$dependencyMap.delete(key);
+        }
+      });
+    }const recursiveCacheFunc = () => ({ $dependencyMap: new Map(), $currentStack: [], recursiveSteps });function recursiveMapOpt($targetObj, $targetKey, identifier, func, src, context, $invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyArr, recursiveCacheFunc);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];const $loop = $storage[4];$loop.$invalidatedKeys = $invalidatedKeys;$loop.$out = $out;$loop.context = context;$loop.func = func;$loop.src = src;$loop.$invalidates = $invalidates;if ($new) {
+        for (let key = 0; key < src.length; key++) {
+          $invalidatedKeys.add(key);
+        }for (let key = 0; key < src.length; key++) {
+          $loop.recursiveSteps(key, $invalidatedKeys, key);
+        }
+      } else {
+        cascadeRecursiveInvalidations($loop);$invalidatedKeys.forEach(key => {
+          $loop.recursiveSteps(key, $invalidatedKeys, key);
+        });
+      }$invalidatedKeys.clear();return $out;
+    }function recursiveMapValuesOpt($targetObj, $targetKey, identifier, func, src, context, $invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyObj, recursiveCacheFunc);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];const $loop = $storage[4];$loop.$invalidatedKeys = $invalidatedKeys;$loop.$out = $out;$loop.context = context;$loop.func = func;$loop.src = src;$loop.$invalidates = $invalidates;if ($new) {
+        Object.keys(src).forEach(key => $invalidatedKeys.add(key));Object.keys(src).forEach(key => $loop.recursiveSteps(key, $invalidatedKeys, key));
+      } else {
+        cascadeRecursiveInvalidations($loop);$invalidatedKeys.forEach(key => {
+          $loop.recursiveSteps(key, $invalidatedKeys, key);
+        });
+      }$invalidatedKeys.clear();return $out;
+    }function keyByOpt($targetObj, $targetKey, identifier, func, src, context, $invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyObj, emptyArr);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];const $idxToKey = $storage[4];if ($new) {
+        for (let key = 0; key < src.length; key++) {
+          const newKey = '' + func($invalidatedKeys, key, src[key], context);$idxToKey[key] = newKey;setOnObject($out, newKey, src[key], $invalidates);
+        }
+      } else {
+        const keysPendingDelete = new Set();$invalidatedKeys.forEach(key => keysPendingDelete.add($idxToKey[key]));$invalidatedKeys.forEach(key => {
+          if (key < src.length) {
+            const newKey = '' + func($invalidatedKeys, key, src[key], context);keysPendingDelete.delete(newKey);$idxToKey[key] = newKey;setOnObject($out, newKey, src[key], $invalidates);
+          }
+        });keysPendingDelete.forEach(key => {
+          triggerInvalidations($out, key, true);delete $out[key];
+        });
+      }$idxToKey.length = src.length;$invalidatedKeys.clear();return $out;
+    }function mapKeysOpt($targetObj, $targetKey, identifier, func, src, context, $invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyObj, emptyObj);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];const $keyToKey = $storage[4];if ($new) {
+        Object.keys(src).forEach(key => {
+          const newKey = func($invalidatedKeys, key, src[key], context);setOnObject($out, newKey, src[key], $invalidates);$keyToKey[key] = newKey;
+        });
+      } else {
+        const keysPendingDelete = new Set();$invalidatedKeys.forEach(key => {
+          if ($keyToKey.hasOwnProperty(key)) {
+            keysPendingDelete.add($keyToKey[key]);delete $keyToKey[key];
+          }
+        });$invalidatedKeys.forEach(key => {
+          if (src.hasOwnProperty(key)) {
+            const newKey = func($invalidatedKeys, key, src[key], context);setOnObject($out, newKey, src[key], $invalidates);$keyToKey[key] = newKey;keysPendingDelete.delete(newKey);
+          }
+        });keysPendingDelete.forEach(key => {
+          deleteOnObject($out, key, $invalidates);
+        });
+      }$invalidatedKeys.clear();return $out;
+    }const filterCacheFunc = () => [0];function filterOpt($targetObj, $targetKey, identifier, func, src, context, $invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyArr, filterCacheFunc);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];const $idxToIdx = $storage[4];if ($new) {
+        for (let key = 0; key < src.length; key++) {
+          const passed = !!func($invalidatedKeys, key, src[key], context);const prevItemIdx = $idxToIdx[key];const nextItemIdx = passed ? prevItemIdx + 1 : prevItemIdx;$idxToIdx[key + 1] = nextItemIdx;if (nextItemIdx !== prevItemIdx) {
+            setOnArray($out, prevItemIdx, src[key], $invalidates);
+          }
+        }
+      } else {
+        let firstIndex = Number.MAX_SAFE_INTEGER;$invalidatedKeys.forEach(key => firstIndex = Math.min(firstIndex, key));for (let key = firstIndex; key < src.length; key++) {
+          const passed = !!func($invalidatedKeys, key, src[key], context);const prevItemIdx = $idxToIdx[key];const nextItemIdx = passed ? prevItemIdx + 1 : prevItemIdx;$idxToIdx[key + 1] = nextItemIdx;if (nextItemIdx !== prevItemIdx) {
+            setOnArray($out, prevItemIdx, src[key], $invalidates);
+          }
+        }$idxToIdx.length = src.length + 1;for (let key = $idxToIdx[$idxToIdx.length - 1]; key < $out.length; key++) {
+          triggerInvalidations($out, key);
+        }$out.length = $idxToIdx[$idxToIdx.length - 1];
+      }$invalidatedKeys.clear();return $out;
+    }function anyOpt($targetObj, $targetKey, identifier, func, src, context, $invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyArr, nullFunc);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3]; // $out has at most 1 key - the one that stopped the previous run because it was truthy
+      if ($new) {
+        for (let key = 0; key < src.length; key++) {
+          $invalidatedKeys.add(key);
+        }
+      }const $prevStop = $out.length > 0 ? $out[0] : -1;if ($prevStop !== -1) {
+        if ($invalidatedKeys.has($prevStop)) {
+          $invalidatedKeys.delete($prevStop);const passedTest = func($invalidatedKeys, $prevStop, src[$prevStop], context);if (passedTest) {
+            return true;
+          } else {
+            $out.length = 0;
+          }
+        } else {
+          return true;
+        }
+      }for (let key of $invalidatedKeys) {
+        $invalidatedKeys.delete(key);if (func($invalidatedKeys, key, src[key], context)) {
+          $out[0] = key;return true;
+        }
+      }return false;
+    }function anyValuesOpt($targetObj, $targetKey, identifier, func, src, context, $invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyArr, nullFunc);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3]; // $out has at most 1 key - the one that stopped the previous run because it was truthy
+      if ($new) {
+        Object.keys(src).forEach(key => $invalidatedKeys.add(key));
+      }const $prevStop = $out.length > 0 ? $out[0] : -1;if ($prevStop !== -1) {
+        if ($invalidatedKeys.has($prevStop)) {
+          $invalidatedKeys.delete($prevStop);const passedTest = func($invalidatedKeys, $prevStop, src[$prevStop], context);if (passedTest) {
+            return true;
+          } else {
+            $out.length = 0;
+          }
+        } else {
+          return true;
+        }
+      }for (let key of $invalidatedKeys) {
+        $invalidatedKeys.delete(key);if (func($invalidatedKeys, key, src[key], context)) {
+          $out[0] = key;return true;
+        }
+      }return false;
+    }function groupByOpt($targetObj, $targetKey, identifier, func, src, context, $invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyObj, emptyObj);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];const $keyToKey = $storage[4];if (Array.isArray(src)) {
+        throw new Error('groupBy only works on objects');
+      }if ($new) {
+        Object.keys(src).forEach(key => {
+          const res = '' + func($invalidatedKeys, key, src[key], context);$keyToKey[key] = res;if (!$out[res]) {
+            setOnObject($out, res, {}, $invalidates);
+          }setOnObject($out[res], key, src[key], $invalidates);
+        });
+      } else {
+        const keysPendingDelete = {};$invalidatedKeys.forEach(key => {
+          if ($keyToKey[key]) {
+            keysPendingDelete[$keyToKey[key]] = keysPendingDelete[$keyToKey[key]] || new Set();keysPendingDelete[$keyToKey[key]].add(key);
+          }
+        });$invalidatedKeys.forEach(key => {
+          const res = '' + func($invalidatedKeys, key, src[key], context);$keyToKey[key] = res;if (!$out[res]) {
+            setOnObject($out, res, {}, $invalidates);
+          }setOnObject($out[res], key, src[key], $invalidates);if (keysPendingDelete.hasOwnProperty(res)) {
+            keysPendingDelete[res].delete(key);
+          }
+        });Object.keys(keysPendingDelete).forEach(res => {
+          if (keysPendingDelete[res].size > 0) {
+            keysPendingDelete[res].forEach(key => {
+              triggerInvalidations($out[res], key);delete $out[res][key];
+            });triggerInvalidations($out, res);if (Object.keys($out[res]).length == 0) {
+              delete $out[res];
+            }
+          }
+        });
+      }$invalidatedKeys.clear();return $out;
+    }const valuesOrKeysCacheFunc = () => ({ $keyToIdx: {}, $idxToKey: [] });function valuesOrKeysForObject($targetObj, $targetKey, identifier, src, getValues) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyArr, valuesOrKeysCacheFunc);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];const { $keyToIdx, $idxToKey } = $storage[4];if ($new) {
+        Object.keys(src).forEach((key, idx) => {
+          $out[idx] = getValues ? src[key] : key;$idxToKey[idx] = key;$keyToIdx[key] = idx;
+        });
+      } else {
+        const $deletedKeys = [];const $addedKeys = [];const $touchedKeys = [];$invalidatedKeys.forEach(key => {
+          if (src.hasOwnProperty(key) && !$keyToIdx.hasOwnProperty(key)) {
+            $addedKeys.push(key);
+          } else if (!src.hasOwnProperty(key) && $keyToIdx.hasOwnProperty(key)) {
+            $deletedKeys.push(key);
+          } else {
+            if ($keyToIdx.hasOwnProperty(key)) {
+              $out[$keyToIdx[key]] = getValues ? src[key] : key;triggerInvalidations($out, $keyToIdx[key]);
+            }
+          }
+        });if ($addedKeys.length < $deletedKeys.length) {
+          $deletedKeys.sort((a, b) => $keyToIdx[a] - $keyToIdx[b]);
+        }const $finalOutLength = $out.length - $deletedKeys.length + $addedKeys.length; // keys both deleted and added fill created holes first
+        for (let i = 0; i < $addedKeys.length && i < $deletedKeys.length; i++) {
+          const $addedKey = $addedKeys[i];const $deletedKey = $deletedKeys[i];const $newIdx = $keyToIdx[$deletedKey];delete $keyToIdx[$deletedKey];$keyToIdx[$addedKey] = $newIdx;$idxToKey[$newIdx] = $addedKey;$out[$newIdx] = getValues ? src[$addedKey] : $addedKey;triggerInvalidations($out, $newIdx);
+        } // more keys added - append to end
+        for (let i = $deletedKeys.length; i < $addedKeys.length; i++) {
+          const $addedKey = $addedKeys[i];const $newIdx = $out.length;$keyToIdx[$addedKey] = $newIdx;$idxToKey[$newIdx] = $addedKey;$out[$newIdx] = getValues ? src[$addedKey] : $addedKey;triggerInvalidations($out, $newIdx);
+        } // more keys deleted - move non deleted items at the tail to the location of deleted
+        const $deletedNotMoved = $deletedKeys.slice($addedKeys.length);const $deletedNotMovedSet = new Set($deletedKeys.slice($addedKeys.length));const $keysToMoveInside = new Set($idxToKey.slice($finalOutLength).filter(key => !$deletedNotMovedSet.has(key)));let $savedCount = 0;for (let $tailIdx = $finalOutLength; $tailIdx < $out.length; $tailIdx++) {
+          const $currentKey = $idxToKey[$tailIdx];if ($keysToMoveInside.has($currentKey)) {
+            // need to move this key to one of the pending delete
+            const $switchedWithDeletedKey = $deletedNotMoved[$savedCount];const $newIdx = $keyToIdx[$switchedWithDeletedKey];$out[$newIdx] = getValues ? src[$currentKey] : $currentKey;$keyToIdx[$currentKey] = $newIdx;$idxToKey[$newIdx] = $currentKey;delete $keyToIdx[$switchedWithDeletedKey];triggerInvalidations($out, $newIdx);$savedCount++;
+          } else {
+            delete $keyToIdx[$currentKey];
+          }triggerInvalidations($out, $tailIdx);
+        }$out.length = $finalOutLength;$idxToKey.length = $out.length;$invalidatedKeys.clear();
+      }return $out;
+    }function getEmptyArray($invalidatedKeys, $targetKey, token) {
+      const subKeys = $invalidatedKeys.$subKeys;const $cachePerTargetKey = subKeys[$targetKey] = subKeys[$targetKey] || new Map();if (!$cachePerTargetKey.has(token)) {
+        $cachePerTargetKey.set(token, []);
+      }return $cachePerTargetKey.get(token);
+    }function getEmptyObject($invalidatedKeys, $targetKey, token) {
+      const subKeys = $invalidatedKeys.$subKeys;const $cachePerTargetKey = subKeys[$targetKey] = subKeys[$targetKey] || new Map();if (!$cachePerTargetKey.has(token)) {
+        $cachePerTargetKey.set(token, {});
+      }return $cachePerTargetKey.get(token);
+    }function array($invalidatedKeys, key, newVal, identifier, len, invalidates) {
+      const res = getEmptyArray($invalidatedKeys, key, identifier);invalidates = invalidates && res.length === len;for (let i = 0; i < len; i++) {
+        setOnArray(res, i, newVal[i], invalidates);
+      }return res;
+    }function object($invalidatedKeys, key, newVal, identifier, keysList, invalidates) {
+      const res = getEmptyObject($invalidatedKeys, key, identifier);invalidates = invalidates && keysList.length && res.hasOwnProperty(keysList[0]);for (let i = 0; i < keysList.length; i++) {
+        const name = keysList[i];setOnObject(res, name, newVal[name], invalidates);
+      }return res;
+    }function call($invalidatedKeys, key, newVal, identifier, len, invalidates) {
+      const arr = getEmptyArray($invalidatedKeys, key, identifier);if (arr.length === 0) {
+        arr.push([]);
+      }const args = arr[0];for (let i = 0; i < len; i++) {
+        setOnArray(args, i, newVal[i], true);
+      }if (arr.length === 1 || $tainted.has(args)) {
+        arr[1] = $funcLib[args[0]].apply($res, args.slice(1));
+      }return arr[1];
+    }function bind($invalidatedKeys, key, newVal, identifier, len) {
+      const arr = getEmptyArray($invalidatedKeys, key, identifier);if (arr.length === 0) {
+        arr.push([]);
+      }const args = arr[0];for (let i = 0; i < len; i++) {
+        args[i] = newVal[i];
+      }if (arr.length === 1) {
+        arr[1] = (...extraArgs) => {
+          const fn = $funcLib[args[0]] || $res[args[0]];return fn.apply($res, args.slice(1).concat(extraArgs));
+        };
+      }return arr[1];
+    }function assignOrDefaults($targetObj, $targetKey, identifier, src, assign, invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyObj, nullFunc);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];if (!assign) {
+        src = [...src].reverse();
+      }if ($new) {
+        Object.assign($out, ...src);
+      } else {
+        const $keysPendingDelete = new Set(Object.keys($out));const res = Object.assign({}, ...src);Object.keys(res).forEach(key => {
+          $keysPendingDelete.delete(key);setOnObject($out, key, res[key], invalidates);
+        });$keysPendingDelete.forEach(key => {
+          delete $out[key];triggerInvalidations($out, key);
+        });$invalidatedKeys.clear();
+      }return $out;
+    }function size($targetObj, $targetKey, src, identifier) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyArr, nullFunc);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];if ($new) {
+        $out[0] = Array.isArray(src) ? src.length : Object.keys(src).length;
+      }if (!$new) {
+        $out[0] = Array.isArray(src) ? src.length : Object.keys(src).length;$invalidatedKeys.clear();
+      }return $out[0];
+    }function range($invalidatedKeys, key, end, start, step, identifier) {
+      const $out = getEmptyArray($invalidatedKeys, key, identifier);if ($out.length === 0) {
+        for (let val = start; step > 0 && val < end || step < 0 && val > end; val += step) {
+          $out.push(val);
+        }
+      } else {
+        let len = 0;for (let val = start; step > 0 && val < end || step < 0 && val > end; val += step) {
+          if ($out[len] !== val) {
+            triggerInvalidations($out, len);
+          }$out[len] = val;len++;
+        }if ($out.length > len) {
+          for (let i = len; i < $out.length; i++) {
+            triggerInvalidations($out, i);
+          }$out.length = len;
+        }
+      }return $out;
     }$invalidatedRoots.add('first');function $firstBuild() {
-      const newValue = $model[0];setOnObject($res, 'first', newValue, false);$invalidatedRoots.delete('first');return $res.first;
+      const acc = $res;const key = 'first';const $invalidatedKeys = $invalidatedRoots;const newValue = $model[0];setOnObject($res, 'first', newValue, false);$invalidatedRoots.delete('first');return $res.first;
     }$invalidatedRoots.add('second');function $secondBuild() {
-      const newValue = $model[1];setOnObject($res, 'second', newValue, false);$invalidatedRoots.delete('second');return $res.second;
-    }let $inBatch = false;let $batchPending = [];function recalculate() {
+      const acc = $res;const key = 'second';const $invalidatedKeys = $invalidatedRoots;const newValue = $model[1];setOnObject($res, 'second', newValue, false);$invalidatedRoots.delete('second');return $res.second;
+    }let $inBatch = false;let $batchPending = [];let $inRecalculate = false;function recalculate() {
       if ($inBatch) {
         return;
-      }$invalidatedRoots.has('first') && $firstBuild();$invalidatedRoots.has('second') && $secondBuild();$tainted = new WeakSet();$first = false;$listeners.forEach(callback => callback());if ($batchPending.length) {
+      }$inRecalculate = true;$invalidatedRoots.has('first') && $firstBuild();$invalidatedRoots.has('second') && $secondBuild();$tainted = new WeakSet();$first = false;$listeners.forEach(callback => callback());$inRecalculate = false;if ($batchPending.length) {
         $res.$endBatch();
+      }
+    }function $setter(func, ...args) {
+      if (!$inBatch && $batchingStrategy) {
+        $batchingStrategy.call($res);$inBatch = true;
+      }if ($inBatch || $inRecalculate) {
+        $batchPending.push({ func, args });
+      } else {
+        func.apply($res, args);recalculate();
       }
     }Object.assign($res, {}, { $startBatch: () => $inBatch = true, $endBatch: () => {
         $inBatch = false;if ($batchPending.length) {
@@ -166,7 +951,7 @@ module.exports = function () {
       }, $removeListener: func => {
         $listeners.delete(func);
       } });recalculate();return $res;
-  }return model;
+  };
 }();
 "
 `;
@@ -183,9 +968,49 @@ const modelBuilder = carmi\`
       ↓ ↓ ↓ ↓ ↓ ↓
 
 const modelBuilder = (function () {
-  'use strict';
-  function model($model, $funcLib, $batchingStrategy) {
-    const $res = { $model };const $listeners = new Set();const $trackingMap = new WeakMap();const $trackedMap = new WeakMap();const $trackingWildcards = new WeakMap();const $invalidatedMap = new WeakMap();const $invalidatedRoots = new Set();$invalidatedRoots.$subKeys = {};$invalidatedRoots.$parentKey = null;$invalidatedRoots.$parent = null;let $first = true;let $tainted = new WeakSet();$invalidatedMap.set($res, $invalidatedRoots);const untrack = ($targetKeySet, $targetKey) => {
+  return function model($model, $funcLib, $batchingStrategy) {
+    'use strict';
+    const $res = { $model };const $listeners = new Set();const $trackingMap = new WeakMap();const $trackedMap = new WeakMap();const $trackingWildcards = new WeakMap();const $invalidatedMap = new WeakMap();const $invalidatedRoots = new Set();$invalidatedRoots.$subKeys = {};$invalidatedRoots.$parentKey = null;$invalidatedRoots.$parent = null;let $first = true;let $tainted = new WeakSet();$invalidatedMap.set($res, $invalidatedRoots);const $uniquePersistentObjects = new Map();const getUniquePersistenObject = id => {
+      if (!$uniquePersistentObjects.has(id)) {
+        $uniquePersistentObjects.set(id, {});
+      }return $uniquePersistentObjects.get(id);
+    };const collectAllItems = (res, obj, prefix) => {
+      if (typeof obj !== 'object') {
+        return;
+      }res.set(obj, prefix);const keys = Array.isArray(obj) ? new Array(obj.length).fill().map((_, idx) => idx) : Object.keys(obj);keys.forEach(idx => {
+        const child = obj[idx];if (typeof child === 'object') {
+          collectAllItems(res, child, \`\${prefix}.\${idx}\`);
+        }
+      });
+    };const serialize = (all, obj) => {
+      if (all.has(obj)) {
+        return all.get(obj);
+      } else if (obj instanceof WeakMap) {
+        return Array.from(all.keys()).reduce((acc, item) => {
+          if (obj.has(item)) {
+            acc[all.get(item)] = serialize(all, obj.get(item));
+          }return acc;
+        }, {});
+      } else if (obj instanceof Map) {
+        return Array.from(obj.keys()).reduce((acc, item) => {
+          if (all.has(item)) {
+            acc[all.get(item)] = serialize(all, obj.get(item));
+          } else {
+            acc[item] = serialize(all, obj.get(item));
+          }return acc;
+        }, {});
+      } else if (obj instanceof Set || obj instanceof Array) {
+        return Array.from(obj).map(x => all.has(x) ? all.get(x) : serialize(all, x));
+      } else if (typeof obj === 'object') {
+        return Object.keys(obj).reduce((acc, key) => {
+          acc[key] = serialize(all, obj[key]);return acc;
+        }, {});
+      } else {
+        return obj;
+      }
+    };const debug = () => {
+      const all = new Map();collectAllItems(all, $model, '$model');collectAllItems(all, $res, '$res');console.log(\`Found \${all.size} records\`);console.log(JSON.stringify(serialize(all, { $trackingMap, $invalidatedMap }), null, 2));
+    };const untrack = ($targetKeySet, $targetKey) => {
       const $tracked = $trackedMap.get($targetKeySet);if (!$tracked || !$tracked[$targetKey]) {
         return;
       }$tracked[$targetKey].forEach(({ $sourceObj, $sourceKey, $target }) => {
@@ -205,6 +1030,32 @@ const modelBuilder = (function () {
           $changed = true;triggerInvalidations($target, $key, $hard);
         }
       }$target[$key] = $val;return $changed;
+    }function deleteOnObject($target, $key, $invalidates) {
+      let $hard = false;if ($invalidates) {
+        if (typeof $target[$key] === 'object' && $target[$key]) {
+          $hard = true;
+        }triggerInvalidations($target, $key, $hard);
+      }const $invalidatedKeys = $invalidatedMap.get($target);if ($invalidatedKeys) {
+        delete $invalidatedKeys.$subKeys[$key];
+      }delete $target[$key];
+    }function setOnArray($target, $key, $val, $invalidates) {
+      let $hard = false;if ($invalidates && !$first) {
+        if (typeof $target[$key] === 'object' && $target[$key] && $target[$key] !== $val) {
+          $hard = true;
+        }if ($hard || $target[$key] !== $val || typeof $target[$key] === 'object' && $tainted.has($val) || !$target.hasOwnProperty($key) && $target[$key] === undefined) {
+          triggerInvalidations($target, $key, $hard);
+        }
+      }$target[$key] = $val;
+    }function track($target, $sourceObj, $sourceKey, $soft) {
+      if (!$trackingMap.has($sourceObj)) {
+        $trackingMap.set($sourceObj, {});
+      }const $track = $trackingMap.get($sourceObj);$track[$sourceKey] = $track[$sourceKey] || new Map();$track[$sourceKey].set($target, $soft);const $tracked = $trackedMap.get($target[0]);$tracked[$target[1]] = $tracked[$target[1]] || [];$tracked[$target[1]].push({ $sourceKey, $sourceObj, $target });
+    }function trackPath($target, $path) {
+      if (!$trackedMap.has($target[0])) {
+        $trackedMap.set($target[0], {});
+      }const $end = $path.length - 2;let $current = $path[0];for (let i = 0; i <= $end; i++) {
+        track($target, $current, $path[i + 1], i !== $end);$current = $current[$path[i + 1]];
+      }
     }function triggerInvalidations($sourceObj, $sourceKey, $hard) {
       $tainted.add($sourceObj);const $track = $trackingMap.get($sourceObj);if ($track && $track.hasOwnProperty($sourceKey)) {
         $track[$sourceKey].forEach(($soft, $target) => {
@@ -217,15 +1068,354 @@ const modelBuilder = (function () {
           invalidate($targetInvalidatedKeys, $sourceKey);
         });
       }
+    }function initOutput($parentInvalidatedKeys, $targetKey, src, func, createDefaultValue, createCacheValue) {
+      const subKeys = $parentInvalidatedKeys.$subKeys;const $cachePerTargetKey = subKeys[$targetKey] = subKeys[$targetKey] || new Map();let $cachedByFunc = $cachePerTargetKey.get(func);if (!$cachedByFunc) {
+        const $resultObj = createDefaultValue();const $cacheValue = createCacheValue();const $invalidatedKeys = new Set();$invalidatedKeys.$subKeys = {};$invalidatedKeys.$parentKey = $targetKey;$invalidatedKeys.$parent = $parentInvalidatedKeys;$invalidatedMap.set($resultObj, $invalidatedKeys);$cachedByFunc = [null, $resultObj, $invalidatedKeys, true, $cacheValue];$cachePerTargetKey.set(func, $cachedByFunc);
+      } else {
+        $cachedByFunc[3] = false;
+      }const $invalidatedKeys = $cachedByFunc[2];const $prevSrc = $cachedByFunc[0];if ($prevSrc !== src) {
+        if ($prevSrc) {
+          // prev mapped to a different collection
+          $trackingWildcards.get($prevSrc).delete($invalidatedKeys);if (Array.isArray($prevSrc)) {
+            $prevSrc.forEach((_item, index) => $invalidatedKeys.add(index));
+          } else {
+            Object.keys($prevSrc).forEach(key => $invalidatedKeys.add(key));
+          }if (Array.isArray(src)) {
+            src.forEach((_item, index) => $invalidatedKeys.add(index));
+          } else {
+            Object.keys(src).forEach(key => $invalidatedKeys.add(key));
+          }
+        }if (!$trackingWildcards.has(src)) {
+          $trackingWildcards.set(src, new Set());
+        }$trackingWildcards.get(src).add($invalidatedKeys);$cachedByFunc[0] = src;
+      }return $cachedByFunc;
+    }const emptyObj = () => {
+      return {};
+    };const emptyArr = () => [];const nullFunc = () => null;function mapValuesOpt($targetObj, $targetKey, identifier, func, src, context, $invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyObj, nullFunc);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];($new && Object.keys(src) || $invalidatedKeys).forEach(key => {
+        if (!src.hasOwnProperty(key)) {
+          if ($out.hasOwnProperty(key)) {
+            deleteOnObject($out, key, $invalidates);
+          }
+        } else {
+          const res = func($invalidatedKeys, key, src[key], context);setOnObject($out, key, res, $invalidates);
+        }
+      });$invalidatedKeys.clear();return $out;
+    }function filterByOpt($targetObj, $targetKey, identifier, func, src, context, $invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyObj, nullFunc);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];($new && Object.keys(src) || $invalidatedKeys).forEach(key => {
+        if (!src.hasOwnProperty(key)) {
+          if ($out.hasOwnProperty(key)) {
+            deleteOnObject($out, key, $invalidates);
+          }
+        } else {
+          const res = func($invalidatedKeys, key, src[key], context);if (res) {
+            setOnObject($out, key, src[key], $invalidates);
+          } else if ($out.hasOwnProperty(key)) {
+            deleteOnObject($out, key, $invalidates);
+          }
+        }
+      });$invalidatedKeys.clear();return $out;
+    }function mapOpt($targetObj, $targetKey, identifier, func, src, context, $invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyArr, nullFunc);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];if ($new) {
+        for (let key = 0; key < src.length; key++) {
+          const res = func($invalidatedKeys, key, src[key], context);setOnArray($out, key, res, $invalidates);
+        }
+      } else {
+        $invalidatedKeys.forEach(key => {
+          if (key >= src.length) {
+            setOnArray($out, key, undefined, $invalidates);$out.length = src.length;
+          } else {
+            const res = func($invalidatedKeys, key, src[key], context);setOnArray($out, key, res, $invalidates);
+          }
+        });
+      }$invalidatedKeys.clear();return $out;
+    }function recursiveSteps(key, $localInvalidatedKeys, $localKey) {
+      const { $dependencyMap, $currentStack, $invalidatedKeys, $out, func, src, context, $invalidates } = this;if ($currentStack.length > 0) {
+        if (!$dependencyMap.has(key)) {
+          $dependencyMap.set(key, []);
+        }$dependencyMap.get(key).push({ $localInvalidatedKeys, $localKey });
+      }if ($invalidatedKeys.has(key)) {
+        $currentStack.push(key);if (Array.isArray($out)) {
+          if (key >= src.length) {
+            setOnArray($out, key, undefined, $invalidates);$out.length = src.length;
+          } else {
+            const newVal = func($invalidatedKeys, key, src[key], context, this);setOnArray($out, key, newVal, $invalidates);
+          }
+        } else {
+          if (!src.hasOwnProperty(key)) {
+            if ($out.hasOwnProperty(key)) {
+              deleteOnObject($out, key, $invalidates);
+            }
+          } else {
+            const newVal = func($invalidatedKeys, key, src[key], context, this);setOnObject($out, key, newVal, $invalidates);
+          }
+        }$invalidatedKeys.delete(key);$currentStack.pop();
+      }return $out[key];
+    }function cascadeRecursiveInvalidations($loop) {
+      const { $dependencyMap, $invalidatedKeys } = $loop;$invalidatedKeys.forEach(key => {
+        if ($dependencyMap.has(key)) {
+          $dependencyMap.get(key).forEach(({ $localInvalidatedKeys, $localKey }) => {
+            invalidate($localInvalidatedKeys, $localKey);
+          });$dependencyMap.delete(key);
+        }
+      });
+    }const recursiveCacheFunc = () => ({ $dependencyMap: new Map(), $currentStack: [], recursiveSteps });function recursiveMapOpt($targetObj, $targetKey, identifier, func, src, context, $invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyArr, recursiveCacheFunc);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];const $loop = $storage[4];$loop.$invalidatedKeys = $invalidatedKeys;$loop.$out = $out;$loop.context = context;$loop.func = func;$loop.src = src;$loop.$invalidates = $invalidates;if ($new) {
+        for (let key = 0; key < src.length; key++) {
+          $invalidatedKeys.add(key);
+        }for (let key = 0; key < src.length; key++) {
+          $loop.recursiveSteps(key, $invalidatedKeys, key);
+        }
+      } else {
+        cascadeRecursiveInvalidations($loop);$invalidatedKeys.forEach(key => {
+          $loop.recursiveSteps(key, $invalidatedKeys, key);
+        });
+      }$invalidatedKeys.clear();return $out;
+    }function recursiveMapValuesOpt($targetObj, $targetKey, identifier, func, src, context, $invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyObj, recursiveCacheFunc);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];const $loop = $storage[4];$loop.$invalidatedKeys = $invalidatedKeys;$loop.$out = $out;$loop.context = context;$loop.func = func;$loop.src = src;$loop.$invalidates = $invalidates;if ($new) {
+        Object.keys(src).forEach(key => $invalidatedKeys.add(key));Object.keys(src).forEach(key => $loop.recursiveSteps(key, $invalidatedKeys, key));
+      } else {
+        cascadeRecursiveInvalidations($loop);$invalidatedKeys.forEach(key => {
+          $loop.recursiveSteps(key, $invalidatedKeys, key);
+        });
+      }$invalidatedKeys.clear();return $out;
+    }function keyByOpt($targetObj, $targetKey, identifier, func, src, context, $invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyObj, emptyArr);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];const $idxToKey = $storage[4];if ($new) {
+        for (let key = 0; key < src.length; key++) {
+          const newKey = '' + func($invalidatedKeys, key, src[key], context);$idxToKey[key] = newKey;setOnObject($out, newKey, src[key], $invalidates);
+        }
+      } else {
+        const keysPendingDelete = new Set();$invalidatedKeys.forEach(key => keysPendingDelete.add($idxToKey[key]));$invalidatedKeys.forEach(key => {
+          if (key < src.length) {
+            const newKey = '' + func($invalidatedKeys, key, src[key], context);keysPendingDelete.delete(newKey);$idxToKey[key] = newKey;setOnObject($out, newKey, src[key], $invalidates);
+          }
+        });keysPendingDelete.forEach(key => {
+          triggerInvalidations($out, key, true);delete $out[key];
+        });
+      }$idxToKey.length = src.length;$invalidatedKeys.clear();return $out;
+    }function mapKeysOpt($targetObj, $targetKey, identifier, func, src, context, $invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyObj, emptyObj);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];const $keyToKey = $storage[4];if ($new) {
+        Object.keys(src).forEach(key => {
+          const newKey = func($invalidatedKeys, key, src[key], context);setOnObject($out, newKey, src[key], $invalidates);$keyToKey[key] = newKey;
+        });
+      } else {
+        const keysPendingDelete = new Set();$invalidatedKeys.forEach(key => {
+          if ($keyToKey.hasOwnProperty(key)) {
+            keysPendingDelete.add($keyToKey[key]);delete $keyToKey[key];
+          }
+        });$invalidatedKeys.forEach(key => {
+          if (src.hasOwnProperty(key)) {
+            const newKey = func($invalidatedKeys, key, src[key], context);setOnObject($out, newKey, src[key], $invalidates);$keyToKey[key] = newKey;keysPendingDelete.delete(newKey);
+          }
+        });keysPendingDelete.forEach(key => {
+          deleteOnObject($out, key, $invalidates);
+        });
+      }$invalidatedKeys.clear();return $out;
+    }const filterCacheFunc = () => [0];function filterOpt($targetObj, $targetKey, identifier, func, src, context, $invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyArr, filterCacheFunc);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];const $idxToIdx = $storage[4];if ($new) {
+        for (let key = 0; key < src.length; key++) {
+          const passed = !!func($invalidatedKeys, key, src[key], context);const prevItemIdx = $idxToIdx[key];const nextItemIdx = passed ? prevItemIdx + 1 : prevItemIdx;$idxToIdx[key + 1] = nextItemIdx;if (nextItemIdx !== prevItemIdx) {
+            setOnArray($out, prevItemIdx, src[key], $invalidates);
+          }
+        }
+      } else {
+        let firstIndex = Number.MAX_SAFE_INTEGER;$invalidatedKeys.forEach(key => firstIndex = Math.min(firstIndex, key));for (let key = firstIndex; key < src.length; key++) {
+          const passed = !!func($invalidatedKeys, key, src[key], context);const prevItemIdx = $idxToIdx[key];const nextItemIdx = passed ? prevItemIdx + 1 : prevItemIdx;$idxToIdx[key + 1] = nextItemIdx;if (nextItemIdx !== prevItemIdx) {
+            setOnArray($out, prevItemIdx, src[key], $invalidates);
+          }
+        }$idxToIdx.length = src.length + 1;for (let key = $idxToIdx[$idxToIdx.length - 1]; key < $out.length; key++) {
+          triggerInvalidations($out, key);
+        }$out.length = $idxToIdx[$idxToIdx.length - 1];
+      }$invalidatedKeys.clear();return $out;
+    }function anyOpt($targetObj, $targetKey, identifier, func, src, context, $invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyArr, nullFunc);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3]; // $out has at most 1 key - the one that stopped the previous run because it was truthy
+      if ($new) {
+        for (let key = 0; key < src.length; key++) {
+          $invalidatedKeys.add(key);
+        }
+      }const $prevStop = $out.length > 0 ? $out[0] : -1;if ($prevStop !== -1) {
+        if ($invalidatedKeys.has($prevStop)) {
+          $invalidatedKeys.delete($prevStop);const passedTest = func($invalidatedKeys, $prevStop, src[$prevStop], context);if (passedTest) {
+            return true;
+          } else {
+            $out.length = 0;
+          }
+        } else {
+          return true;
+        }
+      }for (let key of $invalidatedKeys) {
+        $invalidatedKeys.delete(key);if (func($invalidatedKeys, key, src[key], context)) {
+          $out[0] = key;return true;
+        }
+      }return false;
+    }function anyValuesOpt($targetObj, $targetKey, identifier, func, src, context, $invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyArr, nullFunc);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3]; // $out has at most 1 key - the one that stopped the previous run because it was truthy
+      if ($new) {
+        Object.keys(src).forEach(key => $invalidatedKeys.add(key));
+      }const $prevStop = $out.length > 0 ? $out[0] : -1;if ($prevStop !== -1) {
+        if ($invalidatedKeys.has($prevStop)) {
+          $invalidatedKeys.delete($prevStop);const passedTest = func($invalidatedKeys, $prevStop, src[$prevStop], context);if (passedTest) {
+            return true;
+          } else {
+            $out.length = 0;
+          }
+        } else {
+          return true;
+        }
+      }for (let key of $invalidatedKeys) {
+        $invalidatedKeys.delete(key);if (func($invalidatedKeys, key, src[key], context)) {
+          $out[0] = key;return true;
+        }
+      }return false;
+    }function groupByOpt($targetObj, $targetKey, identifier, func, src, context, $invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyObj, emptyObj);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];const $keyToKey = $storage[4];if (Array.isArray(src)) {
+        throw new Error('groupBy only works on objects');
+      }if ($new) {
+        Object.keys(src).forEach(key => {
+          const res = '' + func($invalidatedKeys, key, src[key], context);$keyToKey[key] = res;if (!$out[res]) {
+            setOnObject($out, res, {}, $invalidates);
+          }setOnObject($out[res], key, src[key], $invalidates);
+        });
+      } else {
+        const keysPendingDelete = {};$invalidatedKeys.forEach(key => {
+          if ($keyToKey[key]) {
+            keysPendingDelete[$keyToKey[key]] = keysPendingDelete[$keyToKey[key]] || new Set();keysPendingDelete[$keyToKey[key]].add(key);
+          }
+        });$invalidatedKeys.forEach(key => {
+          const res = '' + func($invalidatedKeys, key, src[key], context);$keyToKey[key] = res;if (!$out[res]) {
+            setOnObject($out, res, {}, $invalidates);
+          }setOnObject($out[res], key, src[key], $invalidates);if (keysPendingDelete.hasOwnProperty(res)) {
+            keysPendingDelete[res].delete(key);
+          }
+        });Object.keys(keysPendingDelete).forEach(res => {
+          if (keysPendingDelete[res].size > 0) {
+            keysPendingDelete[res].forEach(key => {
+              triggerInvalidations($out[res], key);delete $out[res][key];
+            });triggerInvalidations($out, res);if (Object.keys($out[res]).length == 0) {
+              delete $out[res];
+            }
+          }
+        });
+      }$invalidatedKeys.clear();return $out;
+    }const valuesOrKeysCacheFunc = () => ({ $keyToIdx: {}, $idxToKey: [] });function valuesOrKeysForObject($targetObj, $targetKey, identifier, src, getValues) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyArr, valuesOrKeysCacheFunc);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];const { $keyToIdx, $idxToKey } = $storage[4];if ($new) {
+        Object.keys(src).forEach((key, idx) => {
+          $out[idx] = getValues ? src[key] : key;$idxToKey[idx] = key;$keyToIdx[key] = idx;
+        });
+      } else {
+        const $deletedKeys = [];const $addedKeys = [];const $touchedKeys = [];$invalidatedKeys.forEach(key => {
+          if (src.hasOwnProperty(key) && !$keyToIdx.hasOwnProperty(key)) {
+            $addedKeys.push(key);
+          } else if (!src.hasOwnProperty(key) && $keyToIdx.hasOwnProperty(key)) {
+            $deletedKeys.push(key);
+          } else {
+            if ($keyToIdx.hasOwnProperty(key)) {
+              $out[$keyToIdx[key]] = getValues ? src[key] : key;triggerInvalidations($out, $keyToIdx[key]);
+            }
+          }
+        });if ($addedKeys.length < $deletedKeys.length) {
+          $deletedKeys.sort((a, b) => $keyToIdx[a] - $keyToIdx[b]);
+        }const $finalOutLength = $out.length - $deletedKeys.length + $addedKeys.length; // keys both deleted and added fill created holes first
+        for (let i = 0; i < $addedKeys.length && i < $deletedKeys.length; i++) {
+          const $addedKey = $addedKeys[i];const $deletedKey = $deletedKeys[i];const $newIdx = $keyToIdx[$deletedKey];delete $keyToIdx[$deletedKey];$keyToIdx[$addedKey] = $newIdx;$idxToKey[$newIdx] = $addedKey;$out[$newIdx] = getValues ? src[$addedKey] : $addedKey;triggerInvalidations($out, $newIdx);
+        } // more keys added - append to end
+        for (let i = $deletedKeys.length; i < $addedKeys.length; i++) {
+          const $addedKey = $addedKeys[i];const $newIdx = $out.length;$keyToIdx[$addedKey] = $newIdx;$idxToKey[$newIdx] = $addedKey;$out[$newIdx] = getValues ? src[$addedKey] : $addedKey;triggerInvalidations($out, $newIdx);
+        } // more keys deleted - move non deleted items at the tail to the location of deleted
+        const $deletedNotMoved = $deletedKeys.slice($addedKeys.length);const $deletedNotMovedSet = new Set($deletedKeys.slice($addedKeys.length));const $keysToMoveInside = new Set($idxToKey.slice($finalOutLength).filter(key => !$deletedNotMovedSet.has(key)));let $savedCount = 0;for (let $tailIdx = $finalOutLength; $tailIdx < $out.length; $tailIdx++) {
+          const $currentKey = $idxToKey[$tailIdx];if ($keysToMoveInside.has($currentKey)) {
+            // need to move this key to one of the pending delete
+            const $switchedWithDeletedKey = $deletedNotMoved[$savedCount];const $newIdx = $keyToIdx[$switchedWithDeletedKey];$out[$newIdx] = getValues ? src[$currentKey] : $currentKey;$keyToIdx[$currentKey] = $newIdx;$idxToKey[$newIdx] = $currentKey;delete $keyToIdx[$switchedWithDeletedKey];triggerInvalidations($out, $newIdx);$savedCount++;
+          } else {
+            delete $keyToIdx[$currentKey];
+          }triggerInvalidations($out, $tailIdx);
+        }$out.length = $finalOutLength;$idxToKey.length = $out.length;$invalidatedKeys.clear();
+      }return $out;
+    }function getEmptyArray($invalidatedKeys, $targetKey, token) {
+      const subKeys = $invalidatedKeys.$subKeys;const $cachePerTargetKey = subKeys[$targetKey] = subKeys[$targetKey] || new Map();if (!$cachePerTargetKey.has(token)) {
+        $cachePerTargetKey.set(token, []);
+      }return $cachePerTargetKey.get(token);
+    }function getEmptyObject($invalidatedKeys, $targetKey, token) {
+      const subKeys = $invalidatedKeys.$subKeys;const $cachePerTargetKey = subKeys[$targetKey] = subKeys[$targetKey] || new Map();if (!$cachePerTargetKey.has(token)) {
+        $cachePerTargetKey.set(token, {});
+      }return $cachePerTargetKey.get(token);
+    }function array($invalidatedKeys, key, newVal, identifier, len, invalidates) {
+      const res = getEmptyArray($invalidatedKeys, key, identifier);invalidates = invalidates && res.length === len;for (let i = 0; i < len; i++) {
+        setOnArray(res, i, newVal[i], invalidates);
+      }return res;
+    }function object($invalidatedKeys, key, newVal, identifier, keysList, invalidates) {
+      const res = getEmptyObject($invalidatedKeys, key, identifier);invalidates = invalidates && keysList.length && res.hasOwnProperty(keysList[0]);for (let i = 0; i < keysList.length; i++) {
+        const name = keysList[i];setOnObject(res, name, newVal[name], invalidates);
+      }return res;
+    }function call($invalidatedKeys, key, newVal, identifier, len, invalidates) {
+      const arr = getEmptyArray($invalidatedKeys, key, identifier);if (arr.length === 0) {
+        arr.push([]);
+      }const args = arr[0];for (let i = 0; i < len; i++) {
+        setOnArray(args, i, newVal[i], true);
+      }if (arr.length === 1 || $tainted.has(args)) {
+        arr[1] = $funcLib[args[0]].apply($res, args.slice(1));
+      }return arr[1];
+    }function bind($invalidatedKeys, key, newVal, identifier, len) {
+      const arr = getEmptyArray($invalidatedKeys, key, identifier);if (arr.length === 0) {
+        arr.push([]);
+      }const args = arr[0];for (let i = 0; i < len; i++) {
+        args[i] = newVal[i];
+      }if (arr.length === 1) {
+        arr[1] = (...extraArgs) => {
+          const fn = $funcLib[args[0]] || $res[args[0]];return fn.apply($res, args.slice(1).concat(extraArgs));
+        };
+      }return arr[1];
+    }function assignOrDefaults($targetObj, $targetKey, identifier, src, assign, invalidates) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyObj, nullFunc);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];if (!assign) {
+        src = [...src].reverse();
+      }if ($new) {
+        Object.assign($out, ...src);
+      } else {
+        const $keysPendingDelete = new Set(Object.keys($out));const res = Object.assign({}, ...src);Object.keys(res).forEach(key => {
+          $keysPendingDelete.delete(key);setOnObject($out, key, res[key], invalidates);
+        });$keysPendingDelete.forEach(key => {
+          delete $out[key];triggerInvalidations($out, key);
+        });$invalidatedKeys.clear();
+      }return $out;
+    }function size($targetObj, $targetKey, src, identifier) {
+      const $storage = initOutput($targetObj, $targetKey, src, identifier, emptyArr, nullFunc);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];if ($new) {
+        $out[0] = Array.isArray(src) ? src.length : Object.keys(src).length;
+      }if (!$new) {
+        $out[0] = Array.isArray(src) ? src.length : Object.keys(src).length;$invalidatedKeys.clear();
+      }return $out[0];
+    }function range($invalidatedKeys, key, end, start, step, identifier) {
+      const $out = getEmptyArray($invalidatedKeys, key, identifier);if ($out.length === 0) {
+        for (let val = start; step > 0 && val < end || step < 0 && val > end; val += step) {
+          $out.push(val);
+        }
+      } else {
+        let len = 0;for (let val = start; step > 0 && val < end || step < 0 && val > end; val += step) {
+          if ($out[len] !== val) {
+            triggerInvalidations($out, len);
+          }$out[len] = val;len++;
+        }if ($out.length > len) {
+          for (let i = len; i < $out.length; i++) {
+            triggerInvalidations($out, i);
+          }$out.length = len;
+        }
+      }return $out;
     }$invalidatedRoots.add('all');function $allBuild() {
-      const newValue = $model[\\"list\\"];setOnObject($res, 'all', newValue, false);$invalidatedRoots.delete('all');return $res.all;
+      const acc = $res;const key = 'all';const $invalidatedKeys = $invalidatedRoots;const newValue = $model[\\"list\\"];setOnObject($res, 'all', newValue, false);$invalidatedRoots.delete('all');return $res.all;
     }$invalidatedRoots.add('first');function $firstBuild() {
-      const newValue = $res[\\"all\\"][0];setOnObject($res, 'first', newValue, false);$invalidatedRoots.delete('first');return $res.first;
-    }let $inBatch = false;let $batchPending = [];function recalculate() {
+      const acc = $res;const key = 'first';const $invalidatedKeys = $invalidatedRoots;const newValue = $res[\\"all\\"][0];setOnObject($res, 'first', newValue, false);$invalidatedRoots.delete('first');return $res.first;
+    }let $inBatch = false;let $batchPending = [];let $inRecalculate = false;function recalculate() {
       if ($inBatch) {
         return;
-      }$invalidatedRoots.has('all') && $allBuild();$invalidatedRoots.has('first') && $firstBuild();$tainted = new WeakSet();$first = false;$listeners.forEach(callback => callback());if ($batchPending.length) {
+      }$inRecalculate = true;$invalidatedRoots.has('all') && $allBuild();$invalidatedRoots.has('first') && $firstBuild();$tainted = new WeakSet();$first = false;$listeners.forEach(callback => callback());$inRecalculate = false;if ($batchPending.length) {
         $res.$endBatch();
+      }
+    }function $setter(func, ...args) {
+      if (!$inBatch && $batchingStrategy) {
+        $batchingStrategy.call($res);$inBatch = true;
+      }if ($inBatch || $inRecalculate) {
+        $batchPending.push({ func, args });
+      } else {
+        func.apply($res, args);recalculate();
       }
     }Object.assign($res, {}, { $startBatch: () => $inBatch = true, $endBatch: () => {
         $inBatch = false;if ($batchPending.length) {
@@ -240,7 +1430,7 @@ const modelBuilder = (function () {
       }, $removeListener: func => {
         $listeners.delete(func);
       } });recalculate();return $res;
-  }return model;
+  };
 })();
 "
 `;


### PR DESCRIPTION
### Summary

This PR is an attempt to lower the time it takes Carmi to compile a file. I noticed Rollup takes quite a bit of time on my machine (4 sec out of a 10 sec transpile) on one use case with similar results on other use cases (around 40% of the time), even without running uglify with it. I replaced Rollup with a simple switch case to support different formats so it should be significantly faster.

I also removed the built-in support to minify with UglifyJs: Normally, tools like Webpack would consume Carmi's source (probably as a loader) and would then minify the entire bundle. I don't think we should have built-in support for minifying but we can keep it by running Uglify, just not as a Rollup plugin (Please let me know if I should add this).

Please let me know what you think 🙏 