### PR TITLE
make compiler sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ const model = {
   spliceTodos: splice(),
 };
 
-const todosModel = eval(await compile(model));
+const todosModel = eval(compile(model));
 const todos = todosModel([
   { idx: "1", done: false, task: "write a blog post about carmi" },
   { idx: "2", done: true, task: "publish to npm" },

--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -27,9 +27,9 @@ function resolveTestName(testname, type) {
   }
 }
 
-async function precompileModel(testname, type) {
+function precompileModel(testname, type) {
   const model = require(path.resolve(__dirname, `${testname}.carmi`));
-  const src = await carmi.compile(model, {
+  const src = carmi.compile(model, {
     compiler: type,
     format: 'cjs',
     name: testname,
@@ -46,14 +46,14 @@ function runSingleTest(testname, model, count, changes, batch) {
   });
 }
 
-async function runBenchmarks(testname) {
-  await precompileModel(testname, 'carmi');
-  await precompileModel(testname, 'simple');
+function runBenchmarks(testname) {
+  precompileModel(testname, 'carmi');
+  precompileModel(testname, 'simple');
   const results = [];
   for (let runIndex = 0; runIndex < runsCount; runIndex++) {
     for (let type of testsConfigs[testname]) {
       for (let run of runTypes[type]) {
-        const vals = await runSingleTest(testname, resolveTestName(testname, type), ...runTypesParams[run]);
+        const vals = runSingleTest(testname, resolveTestName(testname, type), ...runTypesParams[run]);
         results.push(Object.assign({ type, run }, vals));
       }
     }
@@ -61,12 +61,16 @@ async function runBenchmarks(testname) {
   return results;
 }
 
-async function runAllBenchmarks() {
+function runAllBenchmarks() {
   const results = {};
   for (let testname of tests) {
-    results[testname] = await runBenchmarks(testname);
+    results[testname] = runBenchmarks(testname);
   }
   require('fs').writeFileSync(path.resolve(__dirname, 'generated', 'results.json'), JSON.stringify(results, null, 2));
 }
 
-runAllBenchmarks().catch(e => console.error(e));
+try {
+  runAllBenchmarks();
+} catch (e) {
+  console.error(e);
+}

--- a/bin/carmi
+++ b/bin/carmi
@@ -51,7 +51,7 @@ async function run() {
     throw e;
     return;
   }
-  const code = await carmi.compile(model, options);
+  const code = carmi.compile(model, options);
   if (options.output) {
     await writeFile(options.output, code);
   } else {

--- a/index.js
+++ b/index.js
@@ -240,7 +240,7 @@ proxyHandler.apply = (target, thisArg, args) => {
   }
 };
 
-async function compile(model, options) {
+function compile(model, options) {
   if (typeof options === 'boolean' || typeof options === 'undefined') {
     options = { compiler: !!options ? 'naive' : 'optimizing' };
   }
@@ -266,7 +266,7 @@ async function compile(model, options) {
   if (options.ast) {
     return JSON.stringify(compiler.getters, null, 2);
   }
-  const rawSource = await compiler.compile();
+  const rawSource = compiler.compile();
   let source = rawSource;
   if (options.prettier) {
     try {
@@ -357,5 +357,5 @@ module.exports = API
 
 
 function withSchema() {
-  return API  
+  return API
 }

--- a/src/__tests__/abstract.js
+++ b/src/__tests__/abstract.js
@@ -17,7 +17,7 @@ describe('test the usage of abstracts', () => {
         const allDone = todos.any(todoItem => todoItem.get('done').not()).not()
         implement(todos, root.get('todos'));
         const model = {allDone, todoTitles, set: setter('todos',arg0)}
-        const optCode = eval(await compile(model, { compiler }));
+        const optCode = eval(compile(model, { compiler }));
         const initialState = {todos: [{text:'first', done: false},{text:'second', done: true}]}
         const inst = optCode(initialState, funcLibrary);
         expect(inst.todoTitles).toEqual(['first','second']);

--- a/src/__tests__/arrays.js
+++ b/src/__tests__/arrays.js
@@ -12,7 +12,7 @@ describe('testing array', () => {
   describeCompilers(['simple', 'optimizing'], compiler => {
     it('simple map', async () => {
       const model = { negated: root.map(val => val.not().call('tap')), set: setter(arg0) };
-      const optCode = eval(await compile(model, { compiler }));
+      const optCode = eval(compile(model, { compiler }));
       const inst = optCode([true, true, false, false, false], funcLibrary);
       expect(inst.negated).toEqual([false, false, true, true, true]);
       expectTapFunctionToHaveBeenCalled(inst.$model.length, compiler);
@@ -22,7 +22,7 @@ describe('testing array', () => {
     });
     it('simple map with effect', async () => {
       const model = { effect: root.map(val => or(val.ternary(chain(true).effect('tap'), null), val)), set: setter(arg0) };
-      const optCode = eval(await compile(model, { compiler }));
+      const optCode = eval(compile(model, { compiler }));
       const inst = optCode([true, true, false, false, false], funcLibrary);
       expect(inst.effect).toEqual([true, true, false, false, false]);
       expectTapFunctionToHaveBeenCalled(inst.$model.filter(k => k).length, { compiler: 'optimizing' });
@@ -35,7 +35,7 @@ describe('testing array', () => {
     });
     it('map return empty object if falsy', async () => {
       const model = { orEmpty: root.map(val => or(val, {}).call('tap')), set: setter(arg0) };
-      const optCode = eval(await compile(model, { compiler }));
+      const optCode = eval(compile(model, { compiler }));
       const inst = optCode([{ x: 1 }, false, { x: 2 }], funcLibrary);
       expect(inst.orEmpty).toEqual([{ x: 1 }, {}, { x: 2 }]);
       expectTapFunctionToHaveBeenCalled(inst.$model.length, compiler);
@@ -45,7 +45,7 @@ describe('testing array', () => {
     });
     it('map return empty object if falsy', async () => {
       const model = { orEmpty: root.map(val => or(val, []).call('tap')), set: setter(arg0) };
-      const optCode = eval(await compile(model, { compiler }));
+      const optCode = eval(compile(model, { compiler }));
       const inst = optCode([[1], false, [2]], funcLibrary);
       expect(inst.orEmpty).toEqual([[1], [], [2]]);
       expectTapFunctionToHaveBeenCalled(inst.$model.length, compiler);
@@ -58,7 +58,7 @@ describe('testing array', () => {
         anyTruthy: root.any(val => val.call('tap')),
         set: setter(arg0)
       };
-      const optModel = eval(await compile(model, { compiler }));
+      const optModel = eval(compile(model, { compiler }));
       const inst = optModel([true, false, false, false, false], funcLibrary);
       expectTapFunctionToHaveBeenCalled(1, compiler);
       expect(inst.anyTruthy).toEqual(true);
@@ -84,7 +84,7 @@ describe('testing array', () => {
         set: setter(arg0),
         splice: splice()
       };
-      const optModel = eval(await compile(model, { compiler }));
+      const optModel = eval(compile(model, { compiler }));
       const inst = optModel([{ idx: 1, text: 'a' }, { idx: 2, text: 'b' }, { idx: 3, text: 'c' }], funcLibrary);
       expectTapFunctionToHaveBeenCalled(3, compiler);
       expect(inst.itemByIdx).toEqual({ 1: 'a', 2: 'b', 3: 'c' });
@@ -110,7 +110,7 @@ describe('testing array', () => {
         setArr: setter('arr', arg0),
         setCompareTo: setter('compareTo')
       };
-      const optModel = eval(await compile(model, { compiler }));
+      const optModel = eval(compile(model, { compiler }));
       const inst = optModel({ arr: [0, 1, 2, 3, 4], compareTo: 2 }, funcLibrary);
       expect(currentValues(inst)).toEqual({
         greaterThan: [false, false, false, true, true],
@@ -141,7 +141,7 @@ describe('testing array', () => {
       const mapOfSum = sumsTuple.map(item => item.get(0).call('tap'));
 
       const model = { mapOfSum, set0: setter(arg0, 0), set1: setter(arg0, 1) };
-      const optCode = eval(await compile(model, { compiler }));
+      const optCode = eval(compile(model, { compiler }));
       const initialData = [[1, 2], [3, 4], [5, 6]];
       const inst = optCode(initialData, funcLibrary);
       expect(inst.mapOfSum).toEqual([3, 7, 11]);
@@ -164,7 +164,7 @@ describe('testing array', () => {
         setInner: setter(arg0, arg1),
         splice: splice()
       };
-      const optCode = eval(await compile(model, { compiler }));
+      const optCode = eval(compile(model, { compiler }));
       const initialData = [{ a: 1 }, { b: 2 }, { a: 5 }];
       const inst = optCode(initialData, funcLibrary);
       expect(currentValues(inst)).toEqual({ assign: { a: 5, b: 2 }, defaults: { a: 1, b: 2 } });
@@ -198,7 +198,7 @@ describe('testing array', () => {
         setStart: setter('start')
       };
       const initialData = { start: 2, end: 5, step: 2 };
-      const optCode = eval(await compile(model, { compiler }));
+      const optCode = eval(compile(model, { compiler }));
       const inst = optCode(initialData, funcLibrary);
       expect(inst.range).toEqual([0, 1, 2, 3, 4]);
       expect(inst.rangeStart).toEqual([2, 3, 4]);
@@ -242,7 +242,7 @@ describe('testing array', () => {
         items: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 0, 2, 2, 2, 2],
         match: 1
       };
-      const optCode = eval(await compile(model, { compiler }));
+      const optCode = eval(compile(model, { compiler }));
       const inst = optCode(initialData, funcLibrary);
       expect(inst.fizzBuzz).toEqual([1, 2, 'fizz', 4, 'buzz']);
       inst.setMatch(0);
@@ -274,7 +274,7 @@ describe('testing array', () => {
           .map(item => item.call('tap')),
         set: setter('skip')
       };
-      const optModel = eval(await compile(model, { compiler }));
+      const optModel = eval(compile(model, { compiler }));
       const initialData = { skip: 3 };
       const inst = optModel(initialData, funcLibrary);
       expect(inst.result).toEqual([0, 3, 6, 9]);
@@ -288,7 +288,7 @@ describe('testing array', () => {
         result: root.reduce((agg, value) => agg.plus(value).call('tap'), 0),
         set: setter(arg0)
       };
-      const optModel = eval(await compile(model, { compiler }));
+      const optModel = eval(compile(model, { compiler }));
       const initialData = [1, 3, 5];
       const inst = optModel(initialData, funcLibrary);
       expect(inst.result).toEqual(9);
@@ -302,7 +302,7 @@ describe('testing array', () => {
         result: root.reduce((agg, value) => agg.plus(value).call('tap'), 0),
         set: setter(arg0)
       };
-      const optModel = eval(await compile(model, { compiler }));
+      const optModel = eval(compile(model, { compiler }));
       const initialData = [];
       const inst = optModel(initialData, funcLibrary);
       expect(inst.result).toEqual(0);
@@ -312,7 +312,7 @@ describe('testing array', () => {
         result: root.sum(),
         set: setter(arg0)
       };
-      const optModel = eval(await compile(model, { compiler }));
+      const optModel = eval(compile(model, { compiler }));
       const initialData = [1, 3, 5];
       const inst = optModel(initialData, funcLibrary);
       expect(inst.result).toEqual(9);
@@ -324,7 +324,7 @@ describe('testing array', () => {
         result: root.sum(),
         set: setter(arg0)
       };
-      const optModel = eval(await compile(model, { compiler }));
+      const optModel = eval(compile(model, { compiler }));
       const initialData = [];
       const inst = optModel(initialData, funcLibrary);
       expect(inst.result).toEqual(0);
@@ -334,7 +334,7 @@ describe('testing array', () => {
         result: root.get('a').concat(root.get('b')),
         set: setter('a', arg0)
       };
-      const optModel = eval(await compile(model, { compiler }));
+      const optModel = eval(compile(model, { compiler }));
       const initialData = {a: [1, 3, 5], b: [2, 6]};
       const inst = optModel(initialData, funcLibrary);
       expect(inst.result).toEqual([1, 3, 5, 2, 6]);
@@ -346,7 +346,7 @@ describe('testing array', () => {
         result: root.get('a').concat(root.get('b')),
         set: setter('a', arg0)
       };
-      const optModel = eval(await compile(model, { compiler }));
+      const optModel = eval(compile(model, { compiler }));
       const initialData = {a: [1, 3, 5], b: []};
       const inst = optModel(initialData, funcLibrary);
       expect(inst.result).toEqual([1, 3, 5]);
@@ -358,7 +358,7 @@ describe('testing array', () => {
       const model = {
         result: root.join('~')
       };
-      const optModel = eval(await compile(model, { compiler }));
+      const optModel = eval(compile(model, { compiler }));
       const inst = optModel(initialData);
       expect(inst.result).toEqual('a~b~c');
     });
@@ -367,7 +367,7 @@ describe('testing array', () => {
       const model = {
         result: root.join('~')
       };
-      const optModel = eval(await compile(model, { compiler }));
+      const optModel = eval(compile(model, { compiler }));
       const inst = optModel(initialData);
       expect(inst.result).toEqual('');
     });
@@ -376,7 +376,7 @@ describe('testing array', () => {
       const model = {
         result: root.append('d')
       };
-      const optModel = eval(await compile(model, { compiler }));
+      const optModel = eval(compile(model, { compiler }));
       const inst = optModel(initialData);
       expect(inst.result).toEqual(['a', 'b', 'c', 'd']);
     });
@@ -385,7 +385,7 @@ describe('testing array', () => {
       const model = {
         result: root.append(['d'])
       };
-      const optModel = eval(await compile(model, { compiler }));
+      const optModel = eval(compile(model, { compiler }));
       const inst = optModel(initialData);
       expect(inst.result).toEqual(['a', 'b', 'c', ['d']]);
     });
@@ -396,7 +396,7 @@ describe('testing array', () => {
         const model = {
           includes: root.get('data').includes(value),
         };
-        const optModel = eval(await compile(model, { compiler }));
+        const optModel = eval(compile(model, { compiler }));
 
         const inst = optModel(initialData);
         expect(inst.includes).toEqual(_.includes(initialData.data, value));
@@ -407,7 +407,7 @@ describe('testing array', () => {
         const model = {
           includes: root.get('data').includes(value),
         };
-        const optModel = eval(await compile(model, { compiler }));
+        const optModel = eval(compile(model, { compiler }));
 
         const inst = optModel(initialData);
         expect(inst.includes).toEqual(_.includes(initialData.data, value));
@@ -420,7 +420,7 @@ describe('testing array', () => {
         const model = {
           findIndex: root.get("data").findIndex(item => item.get("id").eq(findId))
         };
-        const optModel = eval(await compile(model, { compiler }));
+        const optModel = eval(compile(model, { compiler }));
 
         const inst = optModel(initialData);
         expect(inst.findIndex).toEqual(1);
@@ -431,7 +431,7 @@ describe('testing array', () => {
         const model = {
           findIndex: root.get("data").findIndex(item => item.get("id").eq(findId))
         };
-        const optModel = eval(await compile(model, { compiler }));
+        const optModel = eval(compile(model, { compiler }));
 
         const inst = optModel(initialData);
         expect(inst.findIndex).toEqual(0);
@@ -443,7 +443,7 @@ describe('testing array', () => {
         const model = {
           findIndex: root.get("data").findIndex(item => item.get("id").eq(findId))
         };
-        const optModel = eval(await compile(model, { compiler }));
+        const optModel = eval(compile(model, { compiler }));
 
         const inst = optModel(initialData);
         expect(inst.findIndex).toEqual(-1);
@@ -456,7 +456,7 @@ describe('testing array', () => {
         result: indexes.map(idx => valuesInArrays.get(idx).get(0)),
         set: setter(arg0)
       };
-      const optModel = eval(await compile(model, { compiler }));
+      const optModel = eval(compile(model, { compiler }));
       const initialData = [{ arr: [1] }, { val: 2 }, { arr: [3] }];
       const inst = optModel(initialData);
       expect(inst.result).toEqual([1, 2, 3]);
@@ -473,7 +473,7 @@ describe('testing array', () => {
         set: setter(arg0)
       };
       const initialData = [3, 4];
-      const optModel = eval(await compile(model, { compiler }));
+      const optModel = eval(compile(model, { compiler }));
       const extraFn = {
         double: x => x * 2,
         mult: (x, y) => x * y,
@@ -497,7 +497,7 @@ describe('testing array', () => {
       const model = {
         numbers: root.reverse()
       };
-      const optModel = eval(await compile(model, { compiler }));
+      const optModel = eval(compile(model, { compiler }));
       const initialData = [1, 2, 3, 4, 5];
 
       const inst = optModel(initialData);
@@ -507,7 +507,7 @@ describe('testing array', () => {
       const model = {
         first: root.head()
       };
-      const optModel = eval(await compile(model, { compiler }));
+      const optModel = eval(compile(model, { compiler }));
       const initialData = ['a', 2, 3, 4, 5];
 
       const inst = optModel(initialData);
@@ -517,7 +517,7 @@ describe('testing array', () => {
       const model = {
         last: root.last()
       };
-      const optModel = eval(await compile(model, { compiler }));
+      const optModel = eval(compile(model, { compiler }));
       const initialData = [1, 2, 3, 4, 5];
 
       const inst = optModel(initialData);

--- a/src/__tests__/basics.js
+++ b/src/__tests__/basics.js
@@ -73,8 +73,8 @@ describe('simple todo', () => {
   }
 
   it('compare naive and optimized', async () => {
-    const naiveFunc = eval(await compile(TodosModel(), true));
-    const optFunc = eval(await compile(TodosModel()));
+    const naiveFunc = eval(compile(TodosModel(), true));
+    const optFunc = eval(compile(TodosModel()));
     const initialState = {
       todos: generateTestTodoItems(countItems),
       currentTask: '1',

--- a/src/__tests__/debug.js
+++ b/src/__tests__/debug.js
@@ -14,7 +14,7 @@ describe('Tests for usability and debugging carmi', () => {
       const makeSureThisCanBeFound = root.map(item => item.mult(2));
       const res = makeSureThisCanBeFound.map(item => item.plus(80));
       const model = { res, set: setter(arg0) }
-      const optCode = eval(await compile(model, { compiler, debug: true }));
+      const optCode = eval(compile(model, { compiler, debug: true }));
       const inst = optCode([1, 2, 3], funcLibrary);
       expect(inst.res).toEqual([82, 84, 86]);
       const sources = JSON.stringify(inst.$source());
@@ -25,7 +25,7 @@ describe('Tests for usability and debugging carmi', () => {
     it('withName', async () => {
       const negated = withName('negated', root.map(val => val.not()));
       const model = { doubleNegated: negated.map(val => val.not().call('tap')), set: setter(arg0) };
-      const optCode = eval(await compile(model, { compiler }));
+      const optCode = eval(compile(model, { compiler }));
       const inst = optCode([true, 1, 0, false, null], funcLibrary);
       expect(inst.doubleNegated).toEqual([true, true, false, false, false]);
       expectTapFunctionToHaveBeenCalled(inst.$model.length, compiler);
@@ -41,7 +41,7 @@ describe('Tests for usability and debugging carmi', () => {
         test2: chain({test: chain(true)}),
         test3: chain({test: chain(true).not()})
       }
-      const optCode = eval(await compile(model, { compiler }));
+      const optCode = eval(compile(model, { compiler }));
       const inst = optCode([], funcLibrary);
       expect(inst.test1).toEqual({test:true});
       expect(inst.test2).toEqual({test:true});
@@ -70,7 +70,7 @@ describe('Tests for usability and debugging carmi', () => {
       const once = root.map(val => val.call('tap'));
       const twice = root.map(val => val.call('tap')).filter(val => val);
       const model = { once, twice, set: setter(arg0) };
-      const optCode = eval(await compile(model, { compiler }));
+      const optCode = eval(compile(model, { compiler }));
       const inst = optCode([false, 1, 0], funcLibrary);
       expect(inst.once).toEqual([false, 1, 0]);
       expect(inst.twice).toEqual([1]);

--- a/src/__tests__/objects.js
+++ b/src/__tests__/objects.js
@@ -18,7 +18,7 @@ describe('testing objects', () => {
           result: root.get('model').get('kofnae')
           // model: root.get('model')
         };
-        const optModel = eval(await compile(model, { compiler }));
+        const optModel = eval(compile(model, { compiler }));
         const initialData = {
           model: {}
         };
@@ -33,7 +33,7 @@ describe('testing objects', () => {
           result: root.get('model').get('kofnae'),
           model: root.get('model') // TODO Reut - this is the only difference
         };
-        const optModel = eval(await compile(model, { compiler }));
+        const optModel = eval(compile(model, { compiler }));
         const initialData = {
           model: {}
         };
@@ -50,7 +50,7 @@ describe('testing objects', () => {
         ),
         setItem: setter(arg0)
       };
-      const optModel = eval(await compile(model, { compiler }));
+      const optModel = eval(compile(model, { compiler }));
       const initialData = { One: 1, Two: 2, First: 1, Second: 2 };
       const inst = optModel(initialData);
       expect(inst.shared).toEqual({
@@ -74,7 +74,7 @@ describe('testing objects', () => {
         ),
         setItem: setter(arg0)
       };
-      const optModel = eval(await compile(model, { compiler }));
+      const optModel = eval(compile(model, { compiler }));
       const initalData = { One: 1, Two: 2, First: 1, Second: 2 };
       const inst = optModel(initalData);
       expect(inst.shared).toEqual({
@@ -94,7 +94,7 @@ describe('testing objects', () => {
     it('groupBy', async () => {
       const numOfDoneItems = root.groupBy('done').get('true').call('tap').size();
       const model = {numOfDoneItems, update: setter(arg0, 'done')};
-      const optModel = eval(await compile(model, {compiler}));
+      const optModel = eval(compile(model, {compiler}));
       const initialData = {
         a: {done: true, text: 'a'},
         b: {done: true, text: 'b'},
@@ -110,7 +110,7 @@ describe('testing objects', () => {
   it('groupBy when initial data is empty', async () => {
       const doneItems = root.get('data').groupBy('done').get('true').call('tap');
       const model = {doneItems, update: setter('data')};
-      const optModel = eval(await compile(model, {compiler}));
+      const optModel = eval(compile(model, {compiler}));
       const initialData = {
           data: {}
       };
@@ -134,7 +134,7 @@ describe('testing objects', () => {
           .mapValues(item => or(and(translate.get(item), root.get('results').get(translate.get(item))), '')),
         setItem: setter('source', arg0)
       };
-      const optModel = eval(await compile(model, { compiler }));
+      const optModel = eval(compile(model, { compiler }));
       const initalData = {
         source: { One: 'First', Two: 'Second', Three: 'Unknown' },
         results: { a: 'A', b: 'B', c: 'C' }
@@ -153,7 +153,7 @@ describe('testing objects', () => {
 
         set: setter(arg0)
       };
-      const optModel = eval(await compile(model, { compiler }));
+      const optModel = eval(compile(model, { compiler }));
       const initalData = { '1': 'One', '2': 'Two', '3': 'Three' };
       const inst = optModel(initalData, funcLibrary);
       expect(inst.byName).toEqual({
@@ -198,7 +198,7 @@ describe('testing objects', () => {
         setCenter: setter('center'),
         setRange: setter('range')
       };
-      const optModel = eval(await compile(model, { compiler }));
+      const optModel = eval(compile(model, { compiler }));
       const initialData = {
         numbers: {
           eight: 8,
@@ -236,7 +236,7 @@ describe('testing objects', () => {
         .mapValues(val => val.get('done').ternary(val.get('text'), val.get('missingProp')))
         .mapValues(text => text.call('tap'));
       const model = { textsIfDone, update: setter(arg0, 'done') };
-      const optModel = eval(await compile(model, { compiler }));
+      const optModel = eval(compile(model, { compiler }));
       const initialData = {
         a: { done: true, text: 'a' },
         b: { done: true, text: 'b' },
@@ -263,7 +263,7 @@ describe('testing objects', () => {
         updateIdx: setter(arg0, 'idx'),
         updateItem: setter(arg0)
       };
-      const optModel = eval(await compile(model, { compiler }));
+      const optModel = eval(compile(model, { compiler }));
       const initialData = {
         a: { text: 'A', idx: '0' },
         b: { text: 'B', idx: '1' },
@@ -324,7 +324,7 @@ describe('testing objects', () => {
         defined: root.getIn(['a', 'b']),
         notDefined: root.getIn(['c', 'b'])
       };
-      const optModel = eval(await compile(model, { compiler }));
+      const optModel = eval(compile(model, { compiler }));
       const initialData = { a: { b: 1 } };
 
       const inst = optModel(initialData);
@@ -338,7 +338,7 @@ describe('testing objects', () => {
         defined: a.getIn(['b','c','d']),
         notDefined: root.getIn(['b','e', 'b'])
       };
-      const optModel = eval(await compile(model, { compiler }));
+      const optModel = eval(compile(model, { compiler }));
       const initialData = { a: { b: {c: {d: 1}} } };
 
       const inst = optModel(initialData);
@@ -351,7 +351,7 @@ describe('testing objects', () => {
         const model = {
           find: root.find(val => val.eq('something')),
         };
-        const optModel = eval(await compile(model, { compiler }));
+        const optModel = eval(compile(model, { compiler }));
 
         const inst = optModel(initialData);
         expect(inst.find).toEqual('something');
@@ -361,7 +361,7 @@ describe('testing objects', () => {
         const model = {
           find: root.find(val => val.eq('notExists')),
         };
-        const optModel = eval(await compile(model, { compiler }));
+        const optModel = eval(compile(model, { compiler }));
 
         const inst = optModel(initialData);
         expect(inst.find).toEqual(undefined);
@@ -371,7 +371,7 @@ describe('testing objects', () => {
         const model = {
           find: root.find((val, key, ctx) => val.eq(ctx), root.get('b')),
         };
-        const optModel = eval(await compile(model, { compiler }));
+        const optModel = eval(compile(model, { compiler }));
 
         const inst = optModel(initialData);
         expect(inst.find).toEqual('something');
@@ -385,7 +385,7 @@ describe('testing objects', () => {
         const model = {
           setIn: root.get('data').setIn(path, value),
         };
-        const optModel = eval(await compile(model, { compiler }));
+        const optModel = eval(compile(model, { compiler }));
 
         const inst = optModel(initialData);
         expect(inst.setIn).toEqual(_.set(initialData.data, path, value));
@@ -397,7 +397,7 @@ describe('testing objects', () => {
         const model = {
           setIn: root.get('data').setIn(path, value),
         };
-        const optModel = eval(await compile(model, { compiler }));
+        const optModel = eval(compile(model, { compiler }));
 
         const inst = optModel(initialData);
         expect(inst.setIn).toEqual(_.set(initialData.data, path, value));
@@ -409,7 +409,7 @@ describe('testing objects', () => {
         const model = {
           setIn: root.get('data').setIn(path, value),
         };
-        const optModel = eval(await compile(model, { compiler }));
+        const optModel = eval(compile(model, { compiler }));
 
         const inst = optModel(initialData);
         expect(inst.setIn).toEqual(_.set(initialData.data, path, value));
@@ -422,7 +422,7 @@ describe('testing objects', () => {
         const model = {
           includesValue: root.get('data').includesValue(value),
         };
-        const optModel = eval(await compile(model, { compiler }));
+        const optModel = eval(compile(model, { compiler }));
 
         const inst = optModel(initialData);
         expect(inst.includesValue).toEqual(_.includes(initialData.data, value));
@@ -433,7 +433,7 @@ describe('testing objects', () => {
         const model = {
           includesValue: root.get('data').includesValue(value),
         };
-        const optModel = eval(await compile(model, { compiler }));
+        const optModel = eval(compile(model, { compiler }));
 
         const inst = optModel(initialData);
         expect(inst.includesValue).toEqual(_.includes(initialData.data, value));
@@ -446,7 +446,7 @@ describe('testing objects', () => {
         const model = {
           pick: root.get('data').pick(path),
         };
-        const optModel = eval(await compile(model, { compiler }));
+        const optModel = eval(compile(model, { compiler }));
 
         const inst = optModel(initialData);
         expect(inst.pick).toEqual(_.pick(initialData.data, path));
@@ -457,7 +457,7 @@ describe('testing objects', () => {
         const model = {
           pick: root.get('data').pick(path),
         };
-        const optModel = eval(await compile(model, { compiler }));
+        const optModel = eval(compile(model, { compiler }));
 
         const inst = optModel(initialData);
         expect(inst.pick).toEqual(_.pick(initialData.data, path));
@@ -468,7 +468,7 @@ describe('testing objects', () => {
         const model = {
           pick: root.get('data').pick(path),
         };
-        const optModel = eval(await compile(model, { compiler }));
+        const optModel = eval(compile(model, { compiler }));
 
         const inst = optModel(initialData);
         expect(inst.pick).toEqual(_.pick(initialData.data, path));
@@ -479,7 +479,7 @@ describe('testing objects', () => {
         const model = {
           pick: root.get('data').pick(path),
         };
-        const optModel = eval(await compile(model, { compiler }));
+        const optModel = eval(compile(model, { compiler }));
 
         const inst = optModel(initialData);
         expect(inst.pick).toEqual(_.pick(initialData.data, path));
@@ -492,7 +492,7 @@ describe('testing objects', () => {
         const model = {
           has: root.get('data').has(key),
         };
-        const optModel = eval(await compile(model, { compiler }));
+        const optModel = eval(compile(model, { compiler }));
 
         const inst = optModel(initialData);
         expect(inst.has).toEqual(_.has(initialData.data, key));
@@ -503,7 +503,7 @@ describe('testing objects', () => {
         const model = {
           has: root.get('data').has(key),
         };
-        const optModel = eval(await compile(model, { compiler }));
+        const optModel = eval(compile(model, { compiler }));
 
         const inst = optModel(initialData);
         expect(inst.has).toEqual(_.has(initialData.data, key));
@@ -514,7 +514,7 @@ describe('testing objects', () => {
         const model = {
           has: root.get('data').has(key),
         };
-        const optModel = eval(await compile(model, { compiler }));
+        const optModel = eval(compile(model, { compiler }));
 
         const inst = optModel(initialData);
         expect(inst.has).toEqual(_.has(initialData.data, key));
@@ -525,7 +525,7 @@ describe('testing objects', () => {
         defined: root.assignIn([{a: 'women'}]),
         notDefined: root.assignIn([{x: 'men'}])
       };
-      const optModel = eval(await compile(model, { compiler }));
+      const optModel = eval(compile(model, { compiler }));
       const initialData = { a: { b: 1 } };
 
       const inst = optModel(initialData);

--- a/src/__tests__/recursive.js
+++ b/src/__tests__/recursive.js
@@ -20,7 +20,7 @@ describe('testing array', () => {
         ),
         set: setter(arg0)
       };
-      const optModel = eval(await compile(model, { compiler }));
+      const optModel = eval(compile(model, { compiler }));
       const inst = optModel([1, 2, 3, 4, 5], funcLibrary);
       expectTapFunctionToHaveBeenCalled(5, compiler);
       expect(inst.sum).toEqual([1, 3, 6, 10, 15]);
@@ -38,7 +38,7 @@ describe('testing array', () => {
         ),
         set: setter(arg0)
       };
-      const optModel = eval(await compile(model, { compiler }));
+      const optModel = eval(compile(model, { compiler }));
       const initialData = [1, 2, 3, -1, -2, 4];
       const inst = optModel(initialData, funcLibrary);
       expect(inst.chain).toEqual([-1, -1, -1, -1, -2, -2]);
@@ -61,7 +61,7 @@ describe('testing array', () => {
         setDone: setter(arg0, 'done'),
         spliceBlockedBy: splice(arg0, 'subTasks')
       };
-      const optModel = eval(await compile(model, { compiler }));
+      const optModel = eval(compile(model, { compiler }));
       const initialData = {
         a: { done: true, subTasks: [] },
         b: { done: false, subTasks: ['c'] },

--- a/src/__tests__/strings.js
+++ b/src/__tests__/strings.js
@@ -13,7 +13,7 @@ describe('testing string functions', () => {
     function testStringFunction(str, func, args, expected) {
       it(`string function: ${func}`, async () => {
         const model = { transform: root.map(val => val[func](...args).call('tap')) };
-        const optCode = eval(await compile(model, { compiler }));
+        const optCode = eval(compile(model, { compiler }));
         const inst = optCode([str], funcLibrary);
         expect(inst.transform[0]).toEqual(expected);
         expectTapFunctionToHaveBeenCalled(inst.$model.length, compiler);

--- a/src/naive-compiler.js
+++ b/src/naive-compiler.js
@@ -296,7 +296,7 @@ class NaiveCompiler {
     };
   }
 
-  async compile() {
+  compile() {
     return this.mergeTemplate(this.template.base, this.topLevelOverrides());
   }
 

--- a/src/rust-compiler.js
+++ b/src/rust-compiler.js
@@ -187,7 +187,7 @@ class RustCompiler extends NaiveCompiler {
       case 'root':
         return '$model';
       case 'null':
-      
+
       case 'topLevel':
         return `$res`;
       case 'call':
@@ -207,18 +207,18 @@ class RustCompiler extends NaiveCompiler {
     return require('./templates/rust-simple.js');
   }
 
-  async generateAnnotations() {
+  generateAnnotations() {
     const annotationsFile = path.join(__dirname, '..', 'cache', `${this.hash()}.json`);
     console.log(annotationsFile);
     try {
-      const annotations = await readFile(annotationsFile);
+      const annotations = fs.readFileSync(annotationsFile);
       this.annotations = JSON.parse(annotations.toString());
       console.log('annotations: found in cache');
     } catch (e) {
       const flowCompiler = new FlowCompiler(Object.assign({}, this.getters, this.setters), this.options);
-      await flowCompiler.compile();
+      flowCompiler.compile();
       this.annotations = flowCompiler.annotations;
-      await writeFile(annotationsFile, JSON.stringify(this.annotations));
+      fs.writeFileSync(annotationsFile, JSON.stringify(this.annotations));
       console.log('annotations: not found in cache, generated new');
     }
     return this.annotations;
@@ -284,8 +284,8 @@ impl JsConvertable for ${type.name} {
     }
   }
 
-  async compile() {
-    await this.generateAnnotations();
+  compile() {
+    this.generateAnnotations();
     this.annotations = extractAllTypeDeclerations(this.annotations);
     this.types = this.annotations.types;
     this.exprAnnotations = this.annotations.expr;


### PR DESCRIPTION
There's nothing async about it, and it makes integration with build tools, testing frameworks, etc harder:
babel is sync, jest transformers are sync.

After that, we can make the babel plugin just compile, and it will probably make it faster (especially when we have multiple files), because modules will be cached and we won't have the consistent node boot time penalty

cc @noamr @yanivefraim