### PR TITLE
add a missing babylon plugin

### DIFF
--- a/src/analyze-dependencies.js
+++ b/src/analyze-dependencies.js
@@ -25,7 +25,7 @@ function readTS(p) {
 }
 
 function readJS(p) {
-  const ast = parse(p, {sourceType: 'module', plugins: ['typescript', 'objectRestSpread']})
+  const ast = parse(p, {sourceType: 'module', plugins: ['typescript', 'objectRestSpread', 'classProperties']})
 
   const visitors = {
     ImportDeclaration(node, state) {


### PR DESCRIPTION
Carmi cache is broken in cases of `classProperties` usage