### PR TITLE
add switch sugar

### DIFF
--- a/src/__tests__/switch.js
+++ b/src/__tests__/switch.js
@@ -1,0 +1,42 @@
+const { root, compile } = require('../../index');
+const { describeCompilers } = require('../test-utils');
+
+describe('switch', () => {
+  describeCompilers(['simple', 'optimizing'], compiler => {
+    it('should return the result of the matching case tuple', () => {
+      const model = {
+        result: root.get('a').switch([
+          [1, 'One'],
+          [2, 'Two'],
+          [3, 'Three']
+        ])
+      };
+
+      const optModel = eval(compile(model, { compiler }));
+      const initialData = {
+        a: 2
+      };
+
+      const inst = optModel(initialData);
+      expect(inst.result).toEqual('Two');
+    })
+
+    it('should return the default result if no case matches', () => {
+      const model = {
+        result: root.get('a').switch([
+          [1, 'One'],
+          [2, 'Two'],
+          [3, 'Three']
+        ], 'Oops')
+      };
+
+      const optModel = eval(compile(model, { compiler }));
+      const initialData = {
+        a: 4
+      };
+
+      const inst = optModel(initialData);
+      expect(inst.result).toEqual('Oops');
+    })
+  })
+})

--- a/src/sugar.js
+++ b/src/sugar.js
@@ -119,6 +119,16 @@ module.exports = function({chain, or, and}) {
       return array.filter(value => value)
     }
 
+    function switchCase(obj, caseTuples, defaultCase) {
+      return (caseTuples || []).reduce(
+          (result, caseTuple) => obj.eq(caseTuple[0]).ternary(
+              caseTuple[1],
+              result
+          ),
+          defaultCase || chain(null)
+      )
+    }
+
     return {
       getIn,
       includes,
@@ -138,6 +148,7 @@ module.exports = function({chain, or, and}) {
       reverse,
       last,
       head,
-      compact
+      compact,
+      switch: switchCase
     };
 };

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -62,6 +62,16 @@ interface GraphImpl<NativeType, F extends FunctionLibrary> extends GraphBase<Nat
     ternary<Consequence, Alternate>(consequence: Consequence, alternate: Alternate): Graph<Consequence, F> | Graph<Alternate, F>
 
     /**
+     * Resolves to the case that matches equals to the boxed value
+     * 
+     * @param caseTuples An array of pairs between a value and a consequent
+     * @param defaultCase The graph to return in case no given case matches the boxed value
+     */
+    switch<DefaultCase, TupleType extends [Argument<NativeType>, any]>(caseTuples: Array<TupleType>, defaultCase: DefaultCase):
+        Graph<DefaultCase, F> |
+        Graph<TupleType extends [Argument<NativeType>, infer Result] ? Result : never, F>
+
+    /**
      * Returns a boolean graph that resolves to the value of (NativeType === other) 
      * @param other 
      */


### PR DESCRIPTION
Added a small sugar for a switch-case like expression. Comes in handy in case of multiple nested `ternary`s.

Didn't know where I should add tests, didn't seem to fit in any of the existing files, so would love some directions.

Example use case:
```
const expr = obj.switch([
  ['Case1', chain(false)],
  ['Case2', chain(true)],
  ['Case3', chain(true)]
], chain(false)]
```

I've considered other alternatives for the API, but tuples seemed like the most concise way of doing it while staying readable. Also `switch` is a reserved word, but it's not a problem when it's a property on an object (at least it seems so). Do you think another name like `switchCase` is better?