### PR TITLE
Add a test for keyBy's current behavior

### DIFF
--- a/src/__tests__/arrays.js
+++ b/src/__tests__/arrays.js
@@ -98,6 +98,17 @@ describe('testing array', () => {
       inst.splice(0, inst.$model.length, ...reverseArray);
       expect(inst.itemByIdx).toEqual({ 4: 'd', 3: 'e' });
       expectTapFunctionToHaveBeenCalled(0, compiler);
+    });    
+    
+    it('raw keyBy', async () => {
+      const model = {
+        itemByIdx: root.keyBy(val => val.get('idx')),
+        set: setter(arg0),
+        splice: splice()
+      };
+      const optModel = eval(compile(model, { compiler }));
+      const inst = optModel([{ idx: 1, text: 'a', foo: 'bar' }, { idx: 2, text: 'b' }, { idx: 1, text: 'c' }], funcLibrary);
+      expect(inst.itemByIdx).toEqual({1: {idx: 1, text: 'c'}, 2: {idx: 2, text: 'b'}});
     });
     it('simple comparison operations', async () => {
       const arr = root.get('arr');

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -289,7 +289,7 @@ interface ArrayGraphImpl<NativeType extends any[], F extends FunctionLibrary,
     any<Scope>(functor: (value: ValueGraph, key?: KeyGraph, scope?: Scope) => Argument<boolean>, scope?: Scope) : BoolGraph<F>
 
     /**
-     * Returns an object graph that resolves to an object containing keys returned by functor, pointing to their corresponding values.
+     * Returns an object graph that resolves to an object containing keys returned by functor, pointing to their first found corresponding value.
      * 
      * @param functor A function to run for every item of the array, returning a string as a new key
      * @param scope A variable to pass to the functor if inside another functor.


### PR DESCRIPTION
keyBy doesn't behave as documented - it returns the first object for each key rather than an array. Adding a test for this as we probably want to keep this behavior for backward compatibility and add something like arrayGroupBy that would return an array for each key.