### PR TITLE
add conditionalTrace, conditionalBreakpoint and tapTrace to sugar

### DIFF
--- a/src/__tests__/trace.js
+++ b/src/__tests__/trace.js
@@ -1,0 +1,69 @@
+const { root, compile } = require('../../index');
+const { describeCompilers } = require('../test-utils');
+
+describe('trace', () => {
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('conditionalTrace', () => {
+    describeCompilers(['simple', 'optimizing'], compiler => {
+      it('should trace if the condition is met', () => {
+        jest.spyOn(console, 'log').mockReturnValue(undefined)
+
+        const model = {
+          result: root.get('a').conditionalTrace(root.get('a'))
+        };
+
+        const optModel = eval(compile(model, { compiler }));
+        const initialData = {
+          a: true
+        };
+
+        const result = optModel(initialData);
+        expect(result).toHaveProperty('result', true)
+        expect(console.log).toHaveBeenCalled();
+      })
+
+      it('should not trace if the condition is not met', () => {
+        jest.spyOn(console, 'log').mockReturnValue(undefined)
+
+        const model = {
+          result: root.get('a').conditionalTrace(root.get('a'))
+        };
+
+        const optModel = eval(compile(model, { compiler }));
+        const initialData = {
+          a: false
+        };
+
+        const result = optModel(initialData);
+        expect(result).toHaveProperty('result', false)
+        expect(console.log).not.toHaveBeenCalled();
+      })
+    })
+  })
+
+  describe('tapTrace', () => {
+    describeCompilers(['simple', 'optimizing'], compiler => {
+      it('should trace the result of the tap function', () => {
+        jest.spyOn(console, 'log').mockReturnValue(undefined)
+
+        const model = {
+          result: root.get('a').tapTrace(x => x.plus(2))
+        };
+
+        const optModel = eval(compile(model, { compiler }));
+        const initialData = {
+          a: 1
+        };
+
+        const result = optModel(initialData);
+        expect(result).toHaveProperty('result', 1)
+        expect(console.log).toHaveBeenCalledWith({ source: expect.any(String), token: 'plus', value: 3 });
+      })
+    })
+  })
+
+})

--- a/src/sugar.js
+++ b/src/sugar.js
@@ -134,6 +134,24 @@ module.exports = function({chain, or, and}) {
       )
     }
 
+    function conditionalTrace(obj, condition) {
+      return condition.ternary(
+          obj.trace(),
+          obj
+      )
+    }
+
+    function conditionalBreakpoint(obj, condition) {
+      return condition.ternary(
+          obj.breakpoint(),
+          obj
+      )
+    }
+
+    function tapTrace(obj, tapFn) {
+      return or(tapFn(obj).trace().ternary(chain(false), chain(false)), obj)
+    }
+
     return {
       getIn,
       includes,
@@ -154,6 +172,9 @@ module.exports = function({chain, or, and}) {
       head,
       every,
       compact,
-      switch: switchCase
+      switch: switchCase,
+      conditionalTrace,
+      conditionalBreakpoint,
+      tapTrace
     };
 };


### PR DESCRIPTION
Added a few debug helpers to sugar. 
* `condtionalTrace` - trace only if a condition is met
* `conditionalBreakpoint` - breakpoint only if a condition is met
* `tapTrace` - trace a transformation of the current value instead of the current value