### PR TITLE
ansi-colors to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@babel/plugin-transform-typescript": "^7.2.0",
     "@babel/preset-typescript": "^7.1.0",
     "@babel/register": "^7.0.0",
+    "ansi-colors": "^3.2.3",
     "babel-generator": "^6.26.1",
     "babel-plugin-macros": "^2.4.1",
     "babel-preset-react": "^6.24.1",
@@ -57,7 +58,6 @@
     "typescript": "^3.2.1"
   },
   "devDependencies": {
-    "ansi-colors": "^3.2.3",
     "babel-plugin-tester": "^5.5.1",
     "eslint": "^5.12.0",
     "eslint-config-wix-editor": "^7.0.0",


### PR DESCRIPTION
`ansi-colors` is being used in `index.js`, but is missing in deps (it's in dev deps instead).