### PR TITLE
Analyze dependencies gracefully: Always generate a stats file regardless of errors

### DIFF
--- a/bin/carmi
+++ b/bin/carmi
@@ -52,12 +52,13 @@ async function run() {
     rootMode: 'upward',
     extensions: ['.ts', '.js'],
     ignore: [/node_modules/]
-  })
+  });
 
-  const dependencies = analyzeDependencies(absPath);
+  const statsFilePath = path.resolve(options.stats);
+  const dependencies = analyzeDependencies(absPath, statsFilePath);
 
   if (options.stats) {
-    await fs.outputJSON(path.resolve(options.stats), dependencies);
+    await fs.outputJSON(statsFilePath, dependencies);
   }
 
   let code;

--- a/loader.js
+++ b/loader.js
@@ -3,7 +3,6 @@
 
 'use strict';
 
-const path = require('path')
 const execa = require('execa')
 const dargs = require('dargs')
 const tempy = require('tempy')
@@ -25,7 +24,7 @@ module.exports = function CarmiLoader() {
   try {
     compiled = execa.sync('npx', ['carmi', ...dargs(options)]).stdout;
   } finally{
-    require(statsPath).forEach(filePath => {
+    Object.keys(require(statsPath)).forEach(filePath => {
       // Add those modules as loader dependencies
       // See https://webpack.js.org/contribute/writing-a-loader/#loader-dependencies
       this.addDependency(filePath)

--- a/loader.js
+++ b/loader.js
@@ -20,13 +20,17 @@ module.exports = function CarmiLoader() {
     ...loaderOptions
   }
 
-  const {stdout: compiled} = execa.sync('npx', ['carmi', ...dargs(options)]);
+  let compiled;
 
-  require(statsPath).forEach(filePath => {
-    // Add those modules as loader dependencies
-    // See https://webpack.js.org/contribute/writing-a-loader/#loader-dependencies
-    this.addDependency(filePath)
-  });
+  try {
+    compiled = execa.sync('npx', ['carmi', ...dargs(options)]).stdout;
+  } finally{
+    require(statsPath).forEach(filePath => {
+      // Add those modules as loader dependencies
+      // See https://webpack.js.org/contribute/writing-a-loader/#loader-dependencies
+      this.addDependency(filePath)
+    });
+  }
 
   return compiled;
 };

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/core": "^7.2.2",
+    "@babel/parser": "^7.3.3",
     "@babel/plugin-transform-modules-commonjs": "^7.2.0",
     "@babel/plugin-transform-typescript": "^7.2.0",
     "@babel/preset-typescript": "^7.1.0",
@@ -54,8 +55,7 @@
     "prettier": "^1.13.5",
     "resolve": "^1.9.0",
     "tempy": "^0.2.1",
-    "toposort": "^1.0.6",
-    "typescript": "^3.2.1"
+    "toposort": "^1.0.6"
   },
   "devDependencies": {
     "babel-plugin-tester": "^5.5.1",

--- a/src/__tests__/analyze-dependencies.js
+++ b/src/__tests__/analyze-dependencies.js
@@ -4,22 +4,44 @@ const {close, open} = require('fs-extra')
 
 const res = f => resolve(__dirname, '../testData', f);
 
+const resObject = (obj) => {
+  const result = {};
+
+  for (const key in obj) {
+    result[res(key)] = obj[key].map(res);
+  }
+
+  return result;
+}
+
 const fsTouch = filename => open(filename, 'w').then(close);
 
 describe('analyze-dependencies', () => {
   it('should read cjs', () => {
     const deps = analyzeDependencies(res('cjs/a.carmi.js'))
-    expect(deps).toEqual(['cjs/a.carmi.js', 'cjs/b.carmi.js', 'cjs/c.carmi.js'].map(res))
+    expect(deps).toEqual(resObject({
+      'cjs/a.carmi.js': ['cjs/b.carmi.js'],
+      'cjs/b.carmi.js': ['cjs/c.carmi.js'],
+      'cjs/c.carmi.js': []
+    }))
   })
 
   it('should read ts', () => {
     const deps = analyzeDependencies(res('ts/a.carmi.js'))
-    expect(deps).toEqual(['ts/a.carmi.js', 'ts/b.carmi.ts', 'ts/c.carmi.js'].map(res))
+    expect(deps).toEqual(resObject({
+      'ts/a.carmi.js': ['ts/b.carmi.ts'],
+      'ts/b.carmi.ts': ['ts/c.carmi.js'],
+      'ts/c.carmi.js': []
+    }))
   })
 
   it('should read esm', () => {
     const deps = analyzeDependencies(res('esm/a.carmi.js'))
-    expect(deps).toEqual(['esm/a.carmi.js', 'esm/b.carmi.js', 'esm/c.carmi.js'].map(res))
+    expect(deps).toEqual(resObject({
+      'esm/a.carmi.js': ['esm/b.carmi.js'],
+      'esm/b.carmi.js': ['esm/c.carmi.js'],
+      'esm/c.carmi.js': []
+    }))
   })
 
   it('should isUpToDate when output is new', async () => {

--- a/src/analyze-dependencies.js
+++ b/src/analyze-dependencies.js
@@ -55,19 +55,23 @@ function readModule(modulePath, visited, imports) {
   visited.add(modulePath)
   const p = fs.readFileSync(modulePath).toString()
 
-  let childDeps;
+  let childDeps = [];
 
-  switch (path.extname(modulePath)) {
-    case '.ts':
-      childDeps = readTS(p)
-      break;
+  try {
+    switch (path.extname(modulePath)) {
+      case '.ts':
+        childDeps = readTS(p)
+        break;
 
-    case '.js':
-      childDeps = readJS(p)
-      break;
+      case '.js':
+        childDeps = readJS(p)
+        break;
 
-    default:
-      return imports;
+      default:
+        return imports;
+    }
+  } catch (error) {
+    // fail gracefully, we treat this module as if it has no child dependencies
   }
 
   // const childDeps = readJS(p)

--- a/src/analyze-dependencies.js
+++ b/src/analyze-dependencies.js
@@ -2,30 +2,11 @@
 const path = require('path')
 const fs = require('fs-extra')
 const resolve = require('resolve')
-const {parse} = require('babylon');
+const babelParser = require('@babel/parser');
 const walk = require('babylon-walk');
-const ts = require('typescript')
-
-function printAllChildren(node, deps) {
-  for (const c of node.getChildren()) {
-    printAllChildren(c, deps)
-    if (ts.formatSyntaxKind(c.kind) === 'ImportDeclaration') {
-      // console.log(ts.formatSyntaxKind(c.kind))
-      deps.push(c.moduleSpecifier.text)
-    }
-  }
-}
-
-function readTS(p) {
-  const childDeps = [];
-  const sourceFile = ts.createSourceFile('foo.ts', p, ts.ScriptTarget.ES5, true);
-  printAllChildren(sourceFile, childDeps);
-  // console.log(sourceFile)
-  return childDeps
-}
 
 function readJS(p) {
-  const ast = parse(p, {sourceType: 'module', plugins: ['typescript', 'objectRestSpread', 'classProperties']})
+  const ast = babelParser.parse(p, {sourceType: 'module', plugins: ['typescript', 'objectRestSpread', 'classProperties']})
 
   const visitors = {
     ImportDeclaration(node, state) {
@@ -60,9 +41,6 @@ function readModule(modulePath, visited, imports) {
   try {
     switch (path.extname(modulePath)) {
       case '.ts':
-        childDeps = readTS(p)
-        break;
-
       case '.js':
         childDeps = readJS(p)
         break;

--- a/src/analyze-dependencies.js
+++ b/src/analyze-dependencies.js
@@ -154,8 +154,7 @@ function analyzeDependencies(entryFilePath, statsFilePath) {
   return modules;
 }
 
-const getTime = file => fs.statSync(file).mtime
-const isEveryFileBefore = (files, time) => files.every(f => getTime(f) < time)
+const isEveryFileBefore = (files, time) => files.every(f => mtime(f) < time)
 
 /**
  * @param {string[]} deps
@@ -163,9 +162,11 @@ const isEveryFileBefore = (files, time) => files.every(f => getTime(f) < time)
  * @return {boolean}
  */
 function isUpToDate(deps, cacheFilePath) {
+  const depsArray = Object.keys(deps)
+
   try {
-    const outTime = getTime(cacheFilePath)
-    return isEveryFileBefore(deps, outTime)
+    const outTime = mtime(cacheFilePath)
+    return isEveryFileBefore(depsArray, outTime)
   } catch (e) {
     return false
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1795,7 +1795,7 @@ find-cache-dir@^1.0.0:
 
 find-cache-dir@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.0.0.tgz#4c1faed59f45184530fb9d7fa123a4d04a98472d"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.0.0.tgz#4c1faed59f45184530fb9d7fa123a4d04a98472d"
   integrity sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==
   dependencies:
     commondir "^1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -118,6 +118,11 @@
   resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.3.2.tgz#95cdeddfc3992a6ca2a1315191c1679ca32c55cd"
   integrity sha512-QzNUC2RO1gadg+fs21fi0Uu0OuGNzRKEmgCxoLNzbCdoprLwjfmZwzUrpUNfJPaVRwBpDY47A17yYEGWyRelnQ==
 
+"@babel/parser@^7.3.3":
+  version "7.3.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.3.3.tgz#092d450db02bdb6ccb1ca8ffd47d8774a91aef87"
+  integrity sha512-xsH1CJoln2r74hR+y7cg2B5JCPaTh+Hd+EbBRk9nWGSNspuo6krjhX0Om6RnRQuIvFq8wVXCLKH3kwKDYhanSg==
+
 "@babel/plugin-syntax-typescript@^7.2.0":
   version "7.2.0"
   resolved "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.2.0.tgz#55d240536bd314dcbbec70fd949c5cabaed1de29"
@@ -4815,11 +4820,6 @@ typescript@3.2.x:
   version "3.2.4"
   resolved "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
   integrity sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
-
-typescript@^3.2.1:
-  version "3.3.1"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-3.3.1.tgz#6de14e1db4b8a006ac535e482c8ba018c55f750b"
-  integrity sha512-cTmIDFW7O0IHbn1DPYjkiebHxwtCMU+eTy30ZtJNBPF9j2O1ITu5XH2YnBeVRKWHqF+3JQwWJv0Q0aUgX8W7IA==
 
 typical@^2.6.1:
   version "2.6.1"


### PR DESCRIPTION
### Summary

This PR changes Carmi's dependency analysis (used for generating the stats file) graceful. If a file contains syntax errors Carmi will include that file in the stats file but won't include any dependencies this file may have.

This is the use-case: Carmi is being used as a Webpack loader and Webpack is being run in watch mode. Initial compilation goes fine, then a syntax error happens in one of the dependencies of Carmi's entry. Since Carmi blew up and no one update Webpack of any dependencies, fixing the problem won't trigger another Webpack compilation and everything stays broken.
