### PR TITLE
don't rethrow error on parsing errors

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -22,7 +22,7 @@ module.exports = function CarmiLoader() {
   let compiled;
 
   try {
-    compiled = execa.sync('npx', ['carmi', ...dargs(options)]).stdout;
+    compiled = execa.sync('node', [require.resolve('./bin/carmi'), ...dargs(options)]).stdout;
   } finally {
     Object.keys(require(statsPath)).forEach(filePath => {
       // Add those modules as loader dependencies

--- a/src/analyze-dependencies.js
+++ b/src/analyze-dependencies.js
@@ -116,7 +116,6 @@ function analyzeFile(filePath, cache) {
     }
   } catch (error) {
     // fail gracefully, we treat this module as if it has no child dependencies
-    throw error;
   }
 
   return dependencies


### PR DESCRIPTION
Fixed analyze file to not rethrow the error on parsing errors, so that the stats file will still be written in case of parsing errors.

Also remove the use of `npx` and just use `node` to run `carmi` in the loader.