### PR TITLE
Better error message when accessing an unknown property

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ function convertArrayAndObjectsToExpr(v) {
       paths.set(v, path)
     }
   }
-  
+
   if (v === null) {
     return new Token('null');
   } else if (v.constructor === Object) {
@@ -107,7 +107,7 @@ function convertArrayAndObjectsToExpr(v) {
     return createExpr(new Token('array', currentLine()), ...v.map((entry, index) => withPathInfo(entry, index, path)));
   } else if (typeof v === 'boolean' || typeof v === 'string' || typeof v === 'number') {
     return new WrappedPrimitive(v);
-  } 
+  }
     return v;
 }
 
@@ -244,7 +244,7 @@ proxyHandler.get = (target, key) => {
     if (sugar[key]) {
       return (...args) => sugar[key](chain(target), ...args);
     }
-    throw new Error(`unknown token: ${key}, ${JSON.stringify(target)}`);
+    throw new Error(`unknown token: "${key}" at ${currentLine()}`);
   }
   if (key === UnwrappedExpr) {
     if (target[UnwrappedExpr]) {


### PR DESCRIPTION
A small fix and a better error message when accessing an unknown property on a token. I've removed the `JSON.stringify(target)` because the target could actually be a very big expression, and trying to print it blocks the event loop and makes carmi seem stuck. Also I think just printing the source location is better 🤷‍♂️ 