### PR TITLE
Fix a bug in keyBy that didn't take into account multiple indices ret…

### DIFF
--- a/src/__tests__/arrays.js
+++ b/src/__tests__/arrays.js
@@ -126,6 +126,19 @@ describe('testing array', () => {
       const inst = optModel([{idx: 1, text: 'a', foo: 'bar'}, {idx: 2, text: 'b'}, {idx: 1, text: 'c'}], funcLibrary);
       expect(inst.itemByIdx).toEqual({1: {idx: 1, text: 'c'}, 2: {idx: 2, text: 'b'}});
     });
+
+    it('double-valued keyBy', async () => {
+      const model = {
+        asObject: root.keyBy(val => val),
+        set: setter(arg0)
+      };
+      const optModel = eval(compile(model, {compiler}));
+      const inst = optModel(['a', 'a'], funcLibrary);
+      expect(inst.asObject).toEqual({a: 'a'})
+      inst.set(0, 'b')
+      expect(inst.asObject).toEqual({a: 'a', b: 'b'})
+    });
+    
     it('simple comparison operations', async () => {
       const arr = root.get('arr');
       const compareTo = root.get('compareTo');

--- a/src/babelPlugin/__snapshots__/macro.spec.js.snap
+++ b/src/babelPlugin/__snapshots__/macro.spec.js.snap
@@ -239,19 +239,25 @@ module.exports = function () {
         });
       }$invalidatedKeys.clear();return $out;
     }function keyByOpt($tracked, identifier, func, src, context, $invalidates) {
-      const $storage = initOutput($tracked, src, identifier, emptyObj, emptyArr);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];const $idxToKey = $storage[4];if ($new) {
-        for (let key = 0; key < src.length; key++) {
-          const newKey = '' + func([$invalidatedKeys, key], key, src[key], context);$idxToKey[key] = newKey;setOnObject($out, newKey, src[key], $invalidates);
+      const $storage = initOutput($tracked, src, identifier, emptyObj, emptyArr);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];const $cache = $storage[4];if ($new) {
+        $cache.indexToKey = [];$cache.keyToIndices = {};for (let index = 0; index < src.length; index++) {
+          const key = '' + func([$invalidatedKeys, index], index, src[index], context);$cache.indexToKey[index] = key;$cache.keyToIndices[key] = $cache.keyToIndices[key] || new Set();$cache.keyToIndices[key].add(index);setOnObject($out, key, src[index], $invalidates);
         }
       } else {
-        const keysPendingDelete = new Set();$invalidatedKeys.forEach(key => keysPendingDelete.add($idxToKey[key]));$invalidatedKeys.forEach(key => {
-          if (key < src.length) {
-            const newKey = '' + func([$invalidatedKeys, key], key, src[key], context);keysPendingDelete.delete(newKey);$idxToKey[key] = newKey;setOnObject($out, newKey, src[key], $invalidates);
+        const keysPendingDelete = new Set();$invalidatedKeys.forEach(index => {
+          if (index < $cache.indexToKey.length) {
+            const key = $cache.indexToKey[index];$cache.keyToIndices[key].delete(index);if ($cache.keyToIndices[key].size === 0) {
+              delete $cache.keyToIndices[key];keysPendingDelete.add(key);
+            }
+          }
+        });$invalidatedKeys.forEach(index => {
+          if (index < src.length) {
+            const key = '' + func([$invalidatedKeys, index], index, src[index], context);$cache.indexToKey[index] = key;keysPendingDelete.delete(key);$cache.keyToIndices[key] = $cache.keyToIndices[key] || new Set();$cache.keyToIndices[key].add(index);setOnObject($out, key, src[index], $invalidates);
           }
         });keysPendingDelete.forEach(key => {
           deleteOnObject($out, key, $invalidates);
         });
-      }$idxToKey.length = src.length;$invalidatedKeys.clear();return $out;
+      }$cache.indexToKey.length = src.length;$invalidatedKeys.clear();return $out;
     }function mapKeysOpt($tracked, identifier, func, src, context, $invalidates) {
       const $storage = initOutput($tracked, src, identifier, emptyObj, emptyObj);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];const $keyToKey = $storage[4];if ($new) {
         Object.keys(src).forEach(key => {
@@ -807,19 +813,25 @@ module.exports = function () {
         });
       }$invalidatedKeys.clear();return $out;
     }function keyByOpt($tracked, identifier, func, src, context, $invalidates) {
-      const $storage = initOutput($tracked, src, identifier, emptyObj, emptyArr);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];const $idxToKey = $storage[4];if ($new) {
-        for (let key = 0; key < src.length; key++) {
-          const newKey = '' + func([$invalidatedKeys, key], key, src[key], context);$idxToKey[key] = newKey;setOnObject($out, newKey, src[key], $invalidates);
+      const $storage = initOutput($tracked, src, identifier, emptyObj, emptyArr);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];const $cache = $storage[4];if ($new) {
+        $cache.indexToKey = [];$cache.keyToIndices = {};for (let index = 0; index < src.length; index++) {
+          const key = '' + func([$invalidatedKeys, index], index, src[index], context);$cache.indexToKey[index] = key;$cache.keyToIndices[key] = $cache.keyToIndices[key] || new Set();$cache.keyToIndices[key].add(index);setOnObject($out, key, src[index], $invalidates);
         }
       } else {
-        const keysPendingDelete = new Set();$invalidatedKeys.forEach(key => keysPendingDelete.add($idxToKey[key]));$invalidatedKeys.forEach(key => {
-          if (key < src.length) {
-            const newKey = '' + func([$invalidatedKeys, key], key, src[key], context);keysPendingDelete.delete(newKey);$idxToKey[key] = newKey;setOnObject($out, newKey, src[key], $invalidates);
+        const keysPendingDelete = new Set();$invalidatedKeys.forEach(index => {
+          if (index < $cache.indexToKey.length) {
+            const key = $cache.indexToKey[index];$cache.keyToIndices[key].delete(index);if ($cache.keyToIndices[key].size === 0) {
+              delete $cache.keyToIndices[key];keysPendingDelete.add(key);
+            }
+          }
+        });$invalidatedKeys.forEach(index => {
+          if (index < src.length) {
+            const key = '' + func([$invalidatedKeys, index], index, src[index], context);$cache.indexToKey[index] = key;keysPendingDelete.delete(key);$cache.keyToIndices[key] = $cache.keyToIndices[key] || new Set();$cache.keyToIndices[key].add(index);setOnObject($out, key, src[index], $invalidates);
           }
         });keysPendingDelete.forEach(key => {
           deleteOnObject($out, key, $invalidates);
         });
-      }$idxToKey.length = src.length;$invalidatedKeys.clear();return $out;
+      }$cache.indexToKey.length = src.length;$invalidatedKeys.clear();return $out;
     }function mapKeysOpt($tracked, identifier, func, src, context, $invalidates) {
       const $storage = initOutput($tracked, src, identifier, emptyObj, emptyObj);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];const $keyToKey = $storage[4];if ($new) {
         Object.keys(src).forEach(key => {
@@ -1377,19 +1389,25 @@ const modelBuilder = (function () {
         });
       }$invalidatedKeys.clear();return $out;
     }function keyByOpt($tracked, identifier, func, src, context, $invalidates) {
-      const $storage = initOutput($tracked, src, identifier, emptyObj, emptyArr);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];const $idxToKey = $storage[4];if ($new) {
-        for (let key = 0; key < src.length; key++) {
-          const newKey = '' + func([$invalidatedKeys, key], key, src[key], context);$idxToKey[key] = newKey;setOnObject($out, newKey, src[key], $invalidates);
+      const $storage = initOutput($tracked, src, identifier, emptyObj, emptyArr);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];const $cache = $storage[4];if ($new) {
+        $cache.indexToKey = [];$cache.keyToIndices = {};for (let index = 0; index < src.length; index++) {
+          const key = '' + func([$invalidatedKeys, index], index, src[index], context);$cache.indexToKey[index] = key;$cache.keyToIndices[key] = $cache.keyToIndices[key] || new Set();$cache.keyToIndices[key].add(index);setOnObject($out, key, src[index], $invalidates);
         }
       } else {
-        const keysPendingDelete = new Set();$invalidatedKeys.forEach(key => keysPendingDelete.add($idxToKey[key]));$invalidatedKeys.forEach(key => {
-          if (key < src.length) {
-            const newKey = '' + func([$invalidatedKeys, key], key, src[key], context);keysPendingDelete.delete(newKey);$idxToKey[key] = newKey;setOnObject($out, newKey, src[key], $invalidates);
+        const keysPendingDelete = new Set();$invalidatedKeys.forEach(index => {
+          if (index < $cache.indexToKey.length) {
+            const key = $cache.indexToKey[index];$cache.keyToIndices[key].delete(index);if ($cache.keyToIndices[key].size === 0) {
+              delete $cache.keyToIndices[key];keysPendingDelete.add(key);
+            }
+          }
+        });$invalidatedKeys.forEach(index => {
+          if (index < src.length) {
+            const key = '' + func([$invalidatedKeys, index], index, src[index], context);$cache.indexToKey[index] = key;keysPendingDelete.delete(key);$cache.keyToIndices[key] = $cache.keyToIndices[key] || new Set();$cache.keyToIndices[key].add(index);setOnObject($out, key, src[index], $invalidates);
           }
         });keysPendingDelete.forEach(key => {
           deleteOnObject($out, key, $invalidates);
         });
-      }$idxToKey.length = src.length;$invalidatedKeys.clear();return $out;
+      }$cache.indexToKey.length = src.length;$invalidatedKeys.clear();return $out;
     }function mapKeysOpt($tracked, identifier, func, src, context, $invalidates) {
       const $storage = initOutput($tracked, src, identifier, emptyObj, emptyObj);const $out = $storage[1];const $invalidatedKeys = $storage[2];const $new = $storage[3];const $keyToKey = $storage[4];if ($new) {
         Object.keys(src).forEach(key => {


### PR DESCRIPTION
…urning the same key.

When two indices were pointing to the same key and one of them has changed to be a different key, keyBy would have deleted it from the target object, not taking into account that that key is still valid because another key points to it.

Changed the keyBy cache to hold two-way maps (key->index and index->key) so that we can keep track of this.