### PR TITLE
Update type to also fallback to T When there is no match

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -7,7 +7,7 @@ interface AbstractGraph {$isCarmiGraph: true}
 export interface GraphBase<NativeType> extends AbstractGraph {$value: NativeType}
 
 export type AsNative<T> = T extends GraphBase<infer N> ? N : T
-export type Argument<T> = AsNative<T> | GraphBase<T>
+export type Argument<T> = AsNative<T> | GraphBase<T> | T
 type MatchesArguments<Function, Args extends any[]> = Function extends (...args: Args) => any ? true : false
 type AsNativeRecursive<T> =
         AsNative<T> extends any[] ? AsNative<T> :


### PR DESCRIPTION
Hi :wave:
With typescript 3.4.5, there are some errors in TS compilation:
```
carmi-host-extensions/src/aspects/bgScrub/bgScrub.carmi.ts:112:58 - error TS2322: Type 'StringGraph<string, FunctionLibrary>' is not assignable to type 'Argument<StringGraph<string, FunctionLibrary>>'.
  Type 'StringGraph<string, FunctionLibrary>' is not assignable to type 'string'.

112         }, cid).filter(e => e.get('element')).keyBy(e => e.get('compId').plus('_').plus(e.get('name')))).values().assign()
                                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  node_modules/carmi/typings/index.d.ts:428:57
    428     keyBy<Scope, Ret extends Argument<string>>(functor: (value: ValueGraph, key?: KeyGraph, scope?: Scope) => Argument<Ret>, scope?: Scope) :
                                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    The expected type comes from the return type of this signature.
```

There are like 9 of those, but all of them is the same essentially, just in different functions - `map`, `groupBy`, `keyBy`.
