### PR TITLE
Run `babel-register` with a different envName

### DIFF
--- a/bin/carmi
+++ b/bin/carmi
@@ -53,8 +53,9 @@ async function run() {
   require('@babel/register')({
     rootMode: 'upward',
     extensions: ['.ts', '.js'],
-    ignore: [/node_modules/]
-  });
+    ignore: [/node_modules/],
+    envName: 'carmi'
+  })
 
   const statsFilePath = path.resolve(options.stats);
   const dependencies = analyzeDependencies(absPath, statsFilePath);


### PR DESCRIPTION
Carmi uses `babel-register` to transpile user's code while generating the model. `babel-register` uses `rootMode: 'upward'`, so it takes the host project's (`bolt`, in our case) `babel.config`. 
If we run with `production` configuration, for example, Carmi will transpile the user's model with `production` configuration, with no real need (it should always transpile using current node).
I think that choosing `envName: carmi` and not `envName: development` will let us control what we do while transpiling Carmi model, later on.
Thanks!