### PR TITLE
Consider path, debug, prettier and name options for cache invalidation.

### DIFF
--- a/bin/__mocks__/carmi
+++ b/bin/__mocks__/carmi
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const mock = require('mock-require')
+const carmi = require('../../')
+
+// Mock cache directory to allow tests working with own one.
+if (process.env.CACHE_DIR) {
+  mock('find-cache-dir', () => process.env.CACHE_DIR)
+}
+
+// Mock carmi to send compilation call message to the parrent process.
+mock('../..', {
+  ...carmi,
+  compile() {
+    process.send('carmi:compile')
+    return ''
+  }
+})
+
+// Require ogiginal carmi binary after all mocks installed
+require('../carmi')

--- a/bin/carmi
+++ b/bin/carmi
@@ -48,7 +48,13 @@ async function run() {
   }
 
   const absPath = path.resolve(process.cwd(), options.source);
-  const cacheFilePath = getCacheFilePath(absPath);
+  const cacheFilePath = getCacheFilePath({
+    path: absPath,
+    debug: options.debug,
+    format: options.format,
+    prettier: options.prettier,
+    name: options.name,
+  });
 
   require('@babel/register')({
     rootMode: 'upward',

--- a/package.json
+++ b/package.json
@@ -62,14 +62,15 @@
     "toposort": "^1.0.6"
   },
   "devDependencies": {
-    "typedoc": "^0.14.2",
     "babel-plugin-tester": "^5.5.1",
     "eslint": "^5.14.1",
     "eslint-config-wix-editor": "^7.0.0",
     "invert-promise": "^1.0.1",
     "jest": "^23.6.0",
     "mobx": "^5.0.2",
+    "mock-require": "^3.0.3",
     "random-seed": "^0.3.0",
+    "typedoc": "^0.14.2",
     "wnpm-ci": "latest"
   },
   "description": "CARMI - Compiler for Automatic Reactive Modelling of Inference"

--- a/src/get-cache-file-path.js
+++ b/src/get-cache-file-path.js
@@ -4,7 +4,7 @@ const findCacheDir = require('find-cache-dir');
 
 const cacheDir = findCacheDir({name: 'carmi'});
 
-module.exports = absPath => {
-  const hash = crypto.createHash('md5').update(absPath).digest('hex');
+module.exports = options => {
+  const hash = crypto.createHash('md5').update(JSON.stringify(options)).digest('hex');
   return path.resolve(cacheDir, hash);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1924,7 +1924,7 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
-get-caller-file@^1.0.1:
+get-caller-file@^1.0.1, get-caller-file@^1.0.2:
   version "1.0.3"
   resolved "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
   integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
@@ -3329,6 +3329,14 @@ mobx@^5.0.2:
   version "5.9.0"
   resolved "https://registry.npmjs.org/mobx/-/mobx-5.9.0.tgz#a08edd7132787f771409c9c33788a5df66ff7ce7"
   integrity sha512-D3mY1uM3H9BP5duk5tTanrOq92yqetYKsprPJWvkKDrbs+fro59xrpWX+vtr10YoLgJIFz+a4A8lI+4YtqmCUQ==
+
+mock-require@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/mock-require/-/mock-require-3.0.3.tgz#ccd544d9eae81dd576b3f219f69ec867318a1946"
+  integrity sha512-lLzfLHcyc10MKQnNUCv7dMcoY/2Qxd6wJfbqCcVk3LDb8An4hF6ohk5AztrvgKhJCqj36uyzi/p5se+tvyD+Wg==
+  dependencies:
+    get-caller-file "^1.0.2"
+    normalize-path "^2.1.1"
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Currently, we are not considering options that affects the output for cache invalidation.

Сonsistently сalling:
`carmi --source a.js --format cjs`
`carmi --source a.js --debug --format iife`
`carmi --source a.js --pretier`
will return the same result from the cache.

Currently, it creates race condition bug for bolt-main project, where we are running 3 builds at the same time, development build goes faster than production one and we have bolt.carmi.js with enabled `debug` option. Even we are trying to run build w/o debug option, it takes it from the cache created by development build (with debug option).

<img width="1486" alt="Screen Shot 2019-08-08 at 3 37 00 PM" src="https://user-images.githubusercontent.com/1521229/62837477-87aefb80-bc78-11e9-8d30-e0ebd45fed63.png">
<img width="1481" alt="Screen Shot 2019-08-08 at 3 36 50 PM" src="https://user-images.githubusercontent.com/1521229/62837479-8aa9ec00-bc78-11e9-9186-bd2eb74fabc9.png">
