### PR TITLE
Support custom setup file

### DIFF
--- a/bin/carmi
+++ b/bin/carmi
@@ -30,6 +30,7 @@ const optionDefinitions = [
   {name: 'no-coverage', type: Boolean, defaultValue: false, description: 'generate header to disable coverage'},
   {name: 'stats', type: String, defaultValue: '', description: 'generate stats file'},
   {name: 'help', type: Boolean, defaultValue: false, description: 'shows this very help message and quits'},
+  {name: 'setup-file-path', type: String, defaultValue: null, description: 'require a file before starting compilation'},
   {name: 'ast', type: Boolean, defaultValue: false}
 ];
 
@@ -56,12 +57,18 @@ async function run() {
     name: options.name,
   });
 
-  require('@babel/register')({
-    rootMode: 'upward',
-    extensions: ['.ts', '.js'],
-    ignore: [/node_modules/],
-    envName: 'carmi'
-  })
+    // Run custom setup file
+    if (options['setup-file-path']) {
+      require(options['setup-file-path']);
+    } else {
+      // Or use the default setup
+      require('@babel/register')({
+        rootMode: 'upward',
+        extensions: ['.ts', '.js'],
+        ignore: [/node_modules/],
+        envName: 'carmi'
+      })
+    }
 
   const statsFilePath = path.resolve(options.stats);
   const dependencies = analyzeDependencies(absPath, statsFilePath);


### PR DESCRIPTION
### Summary

Currently, Carmi runs `@babel/register` with a specific configuration. This PR adds an option to run a different setup before Carmi runs the user's code.

I need to run Babel with different options, specifically, without `rootMode: upward`. This change shouldn't be a breaking change as I kept the old behavior by default.

I didn't find any tests that cover the CLI and its logic so I didn't add any tests for this.

Please let me know if it makes sense or if I should change anything.
