### PR TITLE
Add git-hash cache scenario.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,19 +142,30 @@ Compiles Carmi files on the fly with a fly webpack loader.
 
 Add this to your webpack configurations:
 
-```
+```js
 module: {
   rules: [
     {
       test: /\.carmi\.js$/,
       exclude: /(node_modules|bower_components)/,
       use: {
-        loader: 'carmi/loader'
+        loader: 'carmi/loader',
+        options: {
+          // Carmi options...
+        }
       }
     }
   ]
 }
 ```
+
+#### Available carmi options:
+**`debug`**: Add debug function to the generated code.  
+**`type-check`**: Add static type checking to the generated code.
+**`no-cache`**: Cache will be ignored. *(It could noticeably affect the build time)*
+**`cache-scenario`** (**`mtime`** *(default)* | **`git-hash`**): Specify which cache scenario you want to use. Each of scenario is collection all dependencies of the entry file and checking if at least one of it was updated. Then cache will be ignored and carmi will compile file from the scratch. The difference is how carmi checks which dependency was updated. **mtime** option will check last modified date of the file. But it won't work for cases when you are going to `git clone` project before each build since git doesn't contain a created/modified file metadata. For this cases **git-hash** option could be useful. It collects state based on git hash of each dependency and invalidate file if some of hash was updated (usually it happens after each git tree modification.) *(Will be ignored if no-cache option is enabled)*
+**`ast`**: Add AST to the output for debug purposes.
+
 
 Then you can just `require('./model.carmi.js')` like a boss
 

--- a/bin/__mocks__/carmi
+++ b/bin/__mocks__/carmi
@@ -3,12 +3,36 @@
 'use strict';
 
 const mock = require('mock-require')
+const crypto = require('crypto');
+const childProcess = require('child_process');
 const carmi = require('../../')
+
+const getHash = input => crypto.createHash('md5').update(input).digest('hex').slice(-7);
+
+const getLsTreeResultLine = (filename, withRandomHash) => {
+  const hashInput = withRandomHash && withRandomHash !== 'undefined' ? Date.now().toString() : filename;
+  return `123456 blob ${getHash(hashInput)} ${filename}`;
+};
 
 // Mock cache directory to allow tests working with own one.
 if (process.env.CACHE_DIR) {
   mock('find-cache-dir', () => process.env.CACHE_DIR)
 }
+
+// Mock git ls-tree call to check git-hash test scenario
+mock('child_process', {
+  ...childProcess,
+  execSync(cmd, ...args) {
+    if (cmd.includes('git ls-tree')) {
+      if (process.env.ERROR_STAGE === 'git-hash') {
+        throw new Error('Oops');
+      }
+      const withRandomHash = process.env.RANDOM_GIT_HASH;
+      return [getLsTreeResultLine('test.carmi.js', withRandomHash), getLsTreeResultLine('test2.carmi.js', withRandomHash)].join('\n');
+    }
+    return childProcess.execSync(cmd, ...args);
+  }
+});
 
 // Mock carmi to send compilation call message to the parrent process.
 mock('../..', {

--- a/bin/carmi
+++ b/bin/carmi
@@ -6,10 +6,15 @@ const commandLineArgs = require('command-line-args');
 const carmi = require('../index');
 const path = require('path');
 const fs = require('fs-extra');
-const {isUpToDate, analyzeDependencies} = require('../src/analyze-dependencies');
+const {isUpToDate, getDependenciesHashes, analyzeDependencies} = require('../src/analyze-dependencies');
 const getCacheFilePath = require('../src/get-cache-file-path');
 const wrapModule = require('../src/wrap-module');
 const base64ArrayBuffer = require('../bytecode/base64-arraybuffer');
+
+const CACHE_SCENARIOS = {
+  mtime: 'mtime',
+  gitHash: 'git-hash'
+};
 
 const optionDefinitions = [
   {name: 'source', type: String, defaultOption: true, description: 'source filename, which exports a carmi model'},
@@ -27,6 +32,7 @@ const optionDefinitions = [
   {name: 'name', type: String, defaultValue: 'model', description: 'name of the output module/function'},
   {name: 'prettier', type: Boolean, defaultValue: false, description: 'run prettier on the output'},
   {name: 'no-cache', type: Boolean, defaultValue: false, description: 'ignore cache'},
+  {name: 'cache-scenario', type: String, defaultValue: CACHE_SCENARIOS.mtime, description: `cache scenario to use (${Object.values(CACHE_SCENARIOS).join(' | ')})`},
   {name: 'no-coverage', type: Boolean, defaultValue: false, description: 'generate header to disable coverage'},
   {name: 'stats', type: String, defaultValue: '', description: 'generate stats file'},
   {name: 'help', type: Boolean, defaultValue: false, description: 'shows this very help message and quits'},
@@ -48,13 +54,6 @@ async function run() {
   }
 
   const absPath = path.resolve(process.cwd(), options.source);
-  const cacheFilePath = getCacheFilePath({
-    path: absPath,
-    debug: options.debug,
-    format: options.format,
-    prettier: options.prettier,
-    name: options.name,
-  });
 
   require('@babel/register')({
     rootMode: 'upward',
@@ -67,14 +66,30 @@ async function run() {
   const dependencies = analyzeDependencies(absPath, statsFilePath);
   const encoding = options.compiler === 'bytecode' ? null : 'utf-8';
 
+  const dependenciesHashes = options['cache-scenario'] === CACHE_SCENARIOS.gitHash ?
+    getDependenciesHashes(dependencies) :
+    null;
+
+  const cacheFilePath = getCacheFilePath({
+    path: absPath,
+    debug: options.debug,
+    format: options.format,
+    prettier: options.prettier,
+    dependenciesHashes,
+    name: options.name
+  });
+
   if (options.stats) {
     await fs.outputJSON(statsFilePath, dependencies);
   }
 
   let code;
 
-  // return from cache
-  if (!options['no-cache'] && fs.existsSync(cacheFilePath) && isUpToDate(dependencies, cacheFilePath)) {
+  // We are using fallback to mtime check if scenario is `git-hash`, but getting hashes was resulted in error.
+  const upToDate = Boolean(dependenciesHashes) || isUpToDate(dependencies, cacheFilePath);
+  const useCache = !options['no-cache'] && fs.existsSync(cacheFilePath) && upToDate;
+  if (useCache) {
+    // return from cache
     code = await fs.readFile(cacheFilePath, encoding);
   } else {
     // run carmi and generate cache

--- a/bin/carmi.spec.js
+++ b/bin/carmi.spec.js
@@ -72,7 +72,7 @@ describe('carmi binary', () => {
       cacheDir = tempy.directory();
     })
 
-    it.only('gets result from cache for same options', async () => {
+    it('gets result from cache for same options', async () => {
       carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug`, {cacheDir});
       carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug`, {cacheDir});
 

--- a/bin/carmi.spec.js
+++ b/bin/carmi.spec.js
@@ -4,7 +4,6 @@ const {exec} = pify(childProcess);
 const path = require('path');
 const tempy = require('tempy');
 const invert = require('invert-promise');
-const carmi = require('../index');
 
 jest.mock('../index');
 
@@ -19,10 +18,14 @@ const CARMI_MODEL = path.resolve(
 );
 
 const runBinary = args => exec(`${BINARY_PATH} ${args}`);
-const getCompileCalls = (args, cacheDir) =>
+const getCompileCalls = (args, {cacheDir, withRandomGitHash, errorStage}) =>
   new Promise((resolve, reject) => {
     const child = childProcess.fork(MOCKED_BINARY_PATH, args.split(' '), {
-      env: {CACHE_DIR: cacheDir}
+      env: {
+        CACHE_DIR: cacheDir,
+        ERROR_STAGE: errorStage,
+        RANDOM_GIT_HASH: withRandomGitHash
+      }
     });
     let compileCalls = 0;
     child.on('message', name => name === 'carmi:compile' && compileCalls++);
@@ -69,24 +72,52 @@ describe('carmi binary', () => {
       cacheDir = tempy.directory();
     })
 
-    it('gets result from cache for same options', async () => {
-      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug`, cacheDir);
-      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug`, cacheDir);
+    it.only('gets result from cache for same options', async () => {
+      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug`, {cacheDir});
+      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug`, {cacheDir});
+
+      expect(carmiCompileCalls).toBe(1);
+    });
+
+    it('works with `cache-scenario=mtime` param result from cache for same options', async () => {
+      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug --cache-scenario=mtime`, {cacheDir});
+      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug --cache-scenario=mtime`, {cacheDir});
+
+      expect(carmiCompileCalls).toBe(1);
+    });
+
+    it('works with `cache-scenario=git-hash` result from cache if file has the same git hash', async () => {
+      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug --cache-scenario=git-hash`, {cacheDir});
+      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug --cache-scenario=git-hash`, {cacheDir});
+
+      expect(carmiCompileCalls).toBe(1);
+    });
+
+    it('works with `cache-scenario=git-hash` result from cache if file has different git hashes', async () => {
+      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug --cache-scenario=git-hash`, {cacheDir});
+      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug --cache-scenario=git-hash`, {cacheDir, withRandomGitHash: true});
+
+      expect(carmiCompileCalls).toBe(2);
+    });
+
+    it('uses fallback tos `cache-scenario=mtime` if `git ls-tree` command failed', async () => {
+      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug --cache-scenario=git-hash`, {cacheDir, errorStage: 'git-hash'});
+      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug --cache-scenario=git-hash`, {cacheDir, errorStage: 'git-hash'});
 
       expect(carmiCompileCalls).toBe(1);
     });
 
     it('doesn\'t get result from cache if debug argument was changed', async () => {
-      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --debug`, cacheDir);
-      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL}`, cacheDir);
+      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --debug`, {cacheDir});
+      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL}`, {cacheDir});
 
       expect(carmiCompileCalls).toBe(2);
     });
 
     it('doesn\'t override cache for different options', async () => {
-      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs`, cacheDir);
-      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format iife`, cacheDir);
-      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs`, cacheDir);
+      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs`, {cacheDir});
+      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format iife`, {cacheDir});
+      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs`, {cacheDir});
 
       expect(carmiCompileCalls).toBe(2);
     });

--- a/src/analyze-dependencies.js
+++ b/src/analyze-dependencies.js
@@ -166,7 +166,6 @@ function isUpToDate(deps, cacheFilePath) {
     const outTime = mtime(cacheFilePath)
     return isEveryFileBefore(depsArray, outTime)
   } catch (e) {
-    console.log('ERROR', e);
     return false
   }
 }
@@ -182,7 +181,7 @@ const getDependenciesHashes = (dependencies) => {
       return total;
     }, []);
   } catch (e) {
-    console.log('ERROR', e);
+    console.warn("Can't use `git ls-tree` for the current cache scenario. Using fallback to `mtime` file check");
     return undefined;
   }
 };


### PR DESCRIPTION

### Why
This PR contains an optimization for cache invalidation. Currently, I'm looking into different projects with attempt to optimize build performance and one of ideas that could be useful is to use cache. Carmi already supports it, but it won't work for example for CI. Or different cases when we are making `git clone`|`git pull`, etc.
Git doesn't contain a created/modified date of the file and this metadata equals latest git action, which is very bad for continuous deployments.

### How
The idea is to add hash `cache-scenario` option which will contain current cache scenario using mtime and new one - using git hashes diff. Since git is an our project representation it contains hashes for each file and when one of it changed + committed, the hash is changing also.

So with git-hash cache scenario we are going to generate list of hashes for each dependency and include it into our md5 hash generation. When one of dependencies changed, the cache filename will be changed and cache will be invalidated. It was a bit optimized (for example we are not using full 40-digits hash, but only latest 7).
This solution is also faster current one, when we are recursively checking every dependency and reading metadata content via `fs.statSync`.

We're also going to have fallback for git-hash scenario. If something went wrong (git is not installed or corrupted for current project), we'll catch it and use regular mtime cache scenario.

### Tests?
I've added tests to cover everything I wrote ahead. If you see what still uncovered please let me know.

### Proof!!!
Tested current branch with bolt project and the result was excellent.
Check `npm run build` command, where all carmi processes are being handled.

Cache is not working, since `isUpToDate` helper which is based on mtime comparison is not working on CI at all. **11:26**:
<img width="461" alt="Screen Shot 2019-10-03 at 1 11 03 PM" src="https://user-images.githubusercontent.com/1521229/66391392-a5c57d80-e9d5-11e9-8fff-d6fb60fc21f3.png">

 The same branch, but git-hash cache scenario was used and caches were used correctly:
**4:09**:
<img width="648" alt="Screen Shot 2019-10-07 at 5 58 26 PM" src="https://user-images.githubusercontent.com/1521229/66391419-b8d84d80-e9d5-11e9-91a3-5d2e9e219086.png">

With cache extraction for CI (for example teamcity: https://github.com/wix-private/wix-fed-scripts/pull/31). For PRs we can use `master` caches for the first build (since diff delta could not affect carmi dependencies) and own caches from the second build.


![image](https://user-images.githubusercontent.com/1521229/66391725-91ce4b80-e9d6-11e9-8859-946298eaab20.png)
