### PR TITLE
Preserve symlinks for modules resolving.

### DIFF
--- a/src/analyze-dependencies.js
+++ b/src/analyze-dependencies.js
@@ -66,7 +66,7 @@ function tryResolveExt(dir, i) {
 
 function tryResolve(basedir, i) {
   try {
-    return resolve.sync(i, {basedir})
+    return resolve.sync(i, {basedir, preserveSymlinks: false})
     // return requireUtil.resolve(i)
   } catch (e) {
     // console.log(i, e)


### PR DESCRIPTION
I found a bug with cache-scenario: `git-hash`, where we are not considering symlinks where building dependencies.

For monorepos it's working fine for all packages that was imported via relative paths (`import ./somemodule.carmi`), but won't work for symlinked ones, since it will return the path of the semantic link (including node_modules) instead of original file.

For example, if I'm importing `bolt-wixapps` from `bolt-main`, and it was symlinked via `santa-mono` build, then it will contain `node_modules/bolt-wixapps/someModule`. `git ls-tree` won't resolve it since `node_modules is ignored by git`. But if we'll use original filepath, it will work fine. Also won't affect `mtime` scenario at all.