### PR TITLE
Find dependencies in ExportNamedDeclaration

### DIFF
--- a/src/analyze-dependencies.js
+++ b/src/analyze-dependencies.js
@@ -15,6 +15,11 @@ function getDependencies(filePath) {
     ImportDeclaration(node, state) {
       state.push(node.source.value)
     },
+    ExportNamedDeclaration(node, state) {
+      if (node.source) {
+        state.push(node.source.value)
+      }
+    },
     CallExpression(node, state) {
       if (node.callee.name === 'require' && node.arguments.length > 0 && node.arguments[0].type === 'StringLiteral') {
         state.push(node.arguments[0].value)
@@ -98,6 +103,7 @@ function analyzeFile(filePath, cache) {
   try {
     switch (path.extname(filePath)) {
       case '.ts':
+      case '.tsx':
       case '.js':
         dependencies = getDependencies(filePath);
         break;


### PR DESCRIPTION
### Summary

This PR fixes cache problems with Carmi that make Webpack not watch source files for changes. Pretty straight-forward.

I also added `.tsx` for files to look for dependencies.
