### PR TITLE
Create Node API for Carmi so Webpack loader won't have to use sub-processes

### DIFF
--- a/api.js
+++ b/api.js
@@ -1,0 +1,99 @@
+const carmi = require('./index')
+const path = require('path')
+const fs = require('fs-extra')
+const {isUpToDate, getDependenciesHashes, analyzeDependencies} = require('./src/analyze-dependencies')
+const getCacheFilePath = require('./src/get-cache-file-path')
+const wrapModule = require('./src/wrap-module')
+const base64ArrayBuffer = require('./bytecode/base64-arraybuffer')
+const {CACHE_SCENARIOS} = require('./src/cache-scenarios')
+const {defaults} = require('lodash')
+
+require('@babel/register')({
+	rootMode: 'upward',
+	extensions: ['.ts', '.js'],
+	ignore: [/node_modules/],
+	envName: 'carmi'
+})
+
+module.exports = function processCarmi(options) {
+	options = defaults(options, {
+		compiler: 'optimizing',
+		debug: false,
+		'type-check': false,
+		format: 'iife',
+		name: 'model',
+		prettier: false,
+		'no-cache': false,
+		'cache-scenario': CACHE_SCENARIOS.mtime,
+		'no-coverage': false,
+		ast: false
+	})
+
+	const statsFilePath = getCacheFilePath({
+		path: options.source
+	})
+
+	const dependencies = analyzeDependencies(options.source, statsFilePath)
+	const encoding = options.compiler === 'bytecode' ? null : 'utf-8'
+
+	const dependenciesHashes =
+		options['cache-scenario'] === CACHE_SCENARIOS.gitHash ? getDependenciesHashes(dependencies) : null
+
+	const cacheFilePath = getCacheFilePath({
+		path: options.source,
+		debug: options.debug,
+		format: options.format,
+		prettier: options.prettier,
+		dependenciesHashes,
+		name: options.name
+	})
+
+	fs.outputJSONSync(statsFilePath, dependencies)
+
+	let code
+
+	// We are using fallback to mtime check if scenario is `git-hash`, but getting hashes was resulted in error.
+	const upToDate = Boolean(dependenciesHashes) || isUpToDate(dependencies, cacheFilePath)
+	const useCache = !options['no-cache'] && fs.existsSync(cacheFilePath) && upToDate
+
+  if (useCache) {
+		// return from cache
+		code = fs.readFileSync(cacheFilePath, encoding)
+	} else {
+		// run carmi and generate cache
+		let model
+
+		try {
+			model = require(options.source)
+		} catch (e) {
+			console.error(`failed to require ${options.source} ${e.stack}`)
+			throw e
+		}
+
+		code = carmi.compile(model, options)
+	}
+
+	if (options['no-coverage'] && typeof code === 'string') {
+		code = `/* istanbul ignore file */
+  ${code}`
+	}
+
+	if (!options['no-cache']) {
+		fs.outputFileSync(cacheFilePath, code, encoding)
+  }
+
+	if (typeof code !== 'string' && options.format !== 'binary') {
+		code = wrapModule(
+			options.format,
+			`require('carmi/bytecode/carmi-instance')('${base64ArrayBuffer.encode(code)}')`,
+			name
+		)
+	}
+
+  if (options['no-coverage'] && typeof code === 'string') {
+		code = `/* istanbul ignore file */
+  ${code}`
+	}
+
+  return {code, dependencies};
+}

--- a/bin/carmi
+++ b/bin/carmi
@@ -6,15 +6,8 @@ const commandLineArgs = require('command-line-args');
 const carmi = require('../index');
 const path = require('path');
 const fs = require('fs-extra');
-const {isUpToDate, getDependenciesHashes, analyzeDependencies} = require('../src/analyze-dependencies');
-const getCacheFilePath = require('../src/get-cache-file-path');
-const wrapModule = require('../src/wrap-module');
-const base64ArrayBuffer = require('../bytecode/base64-arraybuffer');
-
-const CACHE_SCENARIOS = {
-  mtime: 'mtime',
-  gitHash: 'git-hash'
-};
+const processCarmi = require('../api')
+const {CACHE_SCENARIOS} = require('../src/cache-scenarios')
 
 const optionDefinitions = [
   {name: 'source', type: String, defaultOption: true, description: 'source filename, which exports a carmi model'},
@@ -55,71 +48,8 @@ async function run() {
 
   const absPath = path.resolve(process.cwd(), options.source);
 
-  require('@babel/register')({
-    rootMode: 'upward',
-    extensions: ['.ts', '.js'],
-    ignore: [/node_modules/],
-    envName: 'carmi'
-  })
+  const {code} = processCarmi({...options, source: absPath})
 
-  const statsFilePath = path.resolve(options.stats);
-  const dependencies = analyzeDependencies(absPath, statsFilePath);
-  const encoding = options.compiler === 'bytecode' ? null : 'utf-8';
-
-  const dependenciesHashes = options['cache-scenario'] === CACHE_SCENARIOS.gitHash ?
-    getDependenciesHashes(dependencies) :
-    null;
-
-  const cacheFilePath = getCacheFilePath({
-    path: absPath,
-    debug: options.debug,
-    format: options.format,
-    prettier: options.prettier,
-    dependenciesHashes,
-    name: options.name
-  });
-
-  if (options.stats) {
-    await fs.outputJSON(statsFilePath, dependencies);
-  }
-
-  let code;
-
-  // We are using fallback to mtime check if scenario is `git-hash`, but getting hashes was resulted in error.
-  const upToDate = Boolean(dependenciesHashes) || isUpToDate(dependencies, cacheFilePath);
-  const useCache = !options['no-cache'] && fs.existsSync(cacheFilePath) && upToDate;
-  if (useCache) {
-    // return from cache
-    code = await fs.readFile(cacheFilePath, encoding);
-  } else {
-    // run carmi and generate cache
-    let model;
-
-    try {
-      model = require(absPath);
-    } catch (e) {
-      console.error(`failed to require ${options.source} ${e.stack}`);
-      throw e;
-    }
-
-    code = carmi.compile(model, options);
-  }
-
-  if (options['no-coverage'] && typeof code === 'string') {
-    code = `/* istanbul ignore file */
-  ${code}`
-  }
-
-  if (!options['no-cache']) {
-    await fs.outputFile(cacheFilePath, code, encoding)
-  }
-  if (typeof code !== 'string' && options.format !== 'binary') {
-    code = wrapModule(options.format, `require('carmi/bytecode/carmi-instance')('${base64ArrayBuffer.encode(code)}')`, options.name);
-  }
-  if (options['no-coverage'] && typeof code === 'string') {
-    code = `/* istanbul ignore file */
-  ${code}`
-  }
   if (options.output) {
     await fs.outputFile(options.output, code);
   } else {

--- a/loader.js
+++ b/loader.js
@@ -8,15 +8,11 @@ const processCarmi = require('./api')
 
 module.exports = function CarmiLoader() {
 	const callback = this.async()
-	// const statsPath = tempy.file({extension: 'json'})
-	// const tempOutputPath = tempy.file({extension: 'js'})
 	const loaderOptions = loaderUtils.getOptions(this) || {}
 
 	const options = {
 		source: this.getDependencies()[0],
-		// stats: statsPath,
 		format: 'cjs',
-		// output: tempOutputPath,
 		...loaderOptions
 	}
 

--- a/loader.js
+++ b/loader.js
@@ -3,63 +3,34 @@
 
 'use strict'
 
-const execa = require('execa')
-const dargs = require('dargs')
-const tempy = require('tempy')
-const {readFileSync} = require('fs')
 const loaderUtils = require('loader-utils')
-const queue = []
+const processCarmi = require('./api')
 
-async function addToQueue() {
-	const item = {promise: null, resolve: null}
-	queue.push(item)
-	item.promise = new Promise((resolve) => {
-		item.resolve = resolve
-	})
-	if (queue.length > 1) {
-		await queue[queue.length - 2].promise
-	}
-}
-
-function finish() {
-	const item = queue.shift()
-	item.resolve()
-}
-
-async function CarmiLoader(loader) {
-	const callback = loader.async()
-	const statsPath = tempy.file({extension: 'json'})
-	const tempOutputPath = tempy.file({extension: 'js'})
-	const loaderOptions = loaderUtils.getOptions(loader) || {}
+module.exports = function CarmiLoader() {
+	const callback = this.async()
+	// const statsPath = tempy.file({extension: 'json'})
+	// const tempOutputPath = tempy.file({extension: 'js'})
+	const loaderOptions = loaderUtils.getOptions(this) || {}
 
 	const options = {
-		source: loader.getDependencies()[0],
-		stats: statsPath,
+		source: this.getDependencies()[0],
+		// stats: statsPath,
 		format: 'cjs',
-		output: tempOutputPath,
+		// output: tempOutputPath,
 		...loaderOptions
 	}
-	await addToQueue()
-
-	let compiled
-	let err = null
 
 	try {
-		await execa('node', [require.resolve('./bin/carmi'), ...dargs(options)])
-		compiled = readFileSync(tempOutputPath, 'utf8')
-	} catch (e) {
-		err = e || new Error(`Error compiling ${options.source}`)
-	} finally {
-		Object.keys(require(statsPath)).forEach((filePath) => {
+		const {code, dependencies} = processCarmi(options)
+
+		Object.keys(require(dependencies)).forEach((filePath) => {
 			// Add those modules as loader dependencies
 			// See https://webpack.js.org/contribute/writing-a-loader/#loader-dependencies
-			loader.addDependency(filePath)
+			this.addDependency(filePath)
 		})
-	}
-	finish()
-	callback(err, compiled)
-}
 
-module.exports = function CarmiLoaderPublic() {
-	CarmiLoader(this)
+		callback(null, code)
+	} catch (error) {
+		callback(error)
+	}
 }

--- a/src/cache-scenarios.js
+++ b/src/cache-scenarios.js
@@ -1,0 +1,6 @@
+const CACHE_SCENARIOS = {
+	mtime: 'mtime',
+	gitHash: 'git-hash'
+}
+
+module.exports = {CACHE_SCENARIOS}


### PR DESCRIPTION
### Summary

This removes the redundant filesystem IO between Webpack's loader and Carmi. I exposed Node API and used the same API in the CLI (so the CLI is pretty slim now).

From testing locally this doesn't slow the build times, even improves them a bit. If we decide that we want to split it over threads we can use `thread-loader`.
