### PR TITLE
WIP | Fix memory leak with using Error stack.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/core": "^7.2.2",
+    "@babel/helper-module-imports": "^7.10.4",
     "@babel/parser": "^7.3.3",
     "@babel/plugin-transform-modules-commonjs": "^7.2.0",
     "@babel/plugin-transform-typescript": "^7.2.0",
@@ -50,6 +51,7 @@
     "babylon": "^6.18.0",
     "babylon-jsx": "^1.0.0",
     "babylon-walk": "^1.0.2",
+    "callsites": "^3.1.0",
     "command-line-args": "^5.0.2",
     "dargs": "^6.0.0",
     "execa": "^1.0.0",
@@ -62,6 +64,7 @@
     "pify": "^4.0.1",
     "prettier": "^1.16.4",
     "resolve": "^1.10.0",
+    "source-map-support": "^0.5.19",
     "tempy": "^0.2.1",
     "toposort": "^1.0.6"
   },

--- a/src/babelPlugin/index.js
+++ b/src/babelPlugin/index.js
@@ -1,10 +1,12 @@
 'use strict';
-
+const {addSideEffect} = require('@babel/helper-module-imports')
 const isCarmiRegex = /^(.+\.carmi)(?:\.js)?$/;
 const isCarmiFilename = x => isCarmiRegex.test(x);
 const {relative, resolve} = require('path');
 const compileFile = require('./compileFile');
 const babylon = require('@babel/parser');
+
+const IMPORT_SOURCE_MAP_SUPPORT = 'source-map-support/register'
 
 const parseCompiledFile = code => {
   const compiledAST = babylon.parse(code);
@@ -36,6 +38,7 @@ module.exports = function carmiBabelTransform({types: t}) {
           '@carmi',
           ''
         );
+        addSideEffect(path, IMPORT_SOURCE_MAP_SUPPORT)
       },
       CallExpression(path) {
         if (!this.doWork) {return;}

--- a/src/currentLine.js
+++ b/src/currentLine.js
@@ -1,6 +1,8 @@
 'use strict'
 
 const _ = require('lodash')
+const callsites = require('callsites')
+const sourceMapSupport = require('source-map-support')
 const path = require('path')
 const carmiRoot = require('../carmiRoot')
 const testPaths = [
@@ -11,19 +13,46 @@ const testPaths = [
 function isExternalLine(line) {
   const isCarmi = _.includes(line, carmiRoot)
   const isTest = _.some(testPaths, p => _.includes(line, p))
-  const containsLineNumber = _.includes(line, ':')
-  return (!isCarmi || isTest) && containsLineNumber
+  return !isCarmi || isTest
 }
 
 module.exports = () => {
-  const firstExternalLine = (new Error()).stack
-    .split('\n')
-    .slice(1)
-    .find(isExternalLine) || 'unknown'
+  const csites = callsites()
+  const firstExternalCallsite = sourceMapSupport.wrapCallSite(
+    csites.find(
+      callsite => isExternalLine(callsite.getFileName())
+    )
+  )
+  const fileName = firstExternalCallsite.getFileName() || 'unknown'
+  const lineNumber = firstExternalCallsite.getLineNumber()
+  const columnNumber = firstExternalCallsite.getColumnNumber()
+  const fileNameWithoutRootFolder = fileName.substr(fileName.indexOf(path.sep))
 
-  return firstExternalLine
-    .substr(firstExternalLine.indexOf(path.sep))
-    .split(':')
-    .map((str, idx) => idx > 0 ? `${parseInt(str, 10)}` : str)
-    .join(':')
+  const newValue = [
+    fileNameWithoutRootFolder, lineNumber, columnNumber
+  ].join(':')
+
+  // const s = (new Error()).stack
+  // .split('\n')
+  // .slice(1)
+  // const firstExternalLine = s
+  //   .find(isExternalLine) || 'unknown'
+
+  // const oldValue = firstExternalLine
+  //   .substr(firstExternalLine.indexOf(path.sep))
+  //   .split(':')
+  //   .map((str, idx) => idx > 0 ? `${parseInt(str, 10)}` : str)
+  //   .join(':')
+
+  // if (newValue !== oldValue) {
+  //   console.log('#==========#')
+  //   console.log('new: ', newValue, ' s: ', csites.map(csite => {
+  //     const cs = sourceMapSupport.wrapCallSite(csite)
+  //     return `${cs.getFileName()}:${cs.getLineNumber()}:${cs.getColumnNumber()}\n`
+  //   }))
+  //   console.log('old: ', oldValue, ' s: ', s)
+  //   console.log('#==========#')
+  //   return oldValue
+  // }
+  return newValue
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -81,6 +81,13 @@
   dependencies:
     "@babel/types" "^7.7.4"
 
+"@babel/helper-module-imports@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz#4c5c54be04bd31670a7382797d75b9fa2e5b5620"
+  integrity sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==
+  dependencies:
+    "@babel/types" "^7.10.4"
+
 "@babel/helper-module-imports@^7.7.4":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.7.4.tgz#e5a92529f8888bf319a6376abfbd1cebc491ad91"
@@ -136,6 +143,11 @@
   integrity sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==
   dependencies:
     "@babel/types" "^7.7.4"
+
+"@babel/helper-validator-identifier@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"
+  integrity sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==
 
 "@babel/helpers@^7.7.4":
   version "7.7.4"
@@ -235,6 +247,15 @@
     debug "^4.1.0"
     globals "^11.1.0"
     lodash "^4.17.13"
+
+"@babel/types@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.10.4.tgz#369517188352e18219981efd156bfdb199fff1ee"
+  integrity sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.4"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
 
 "@babel/types@^7.7.4":
   version "7.7.4"
@@ -980,7 +1001,7 @@ callsites@^2.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
   integrity sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=
 
-callsites@^3.0.0:
+callsites@^3.0.0, callsites@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
@@ -4515,6 +4536,14 @@ source-map-support@^0.5.16:
   version "0.5.16"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042"
   integrity sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map-support@^0.5.19:
+  version "0.5.19"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
+  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"


### PR DESCRIPTION
line of code `(new Error()).stack` led to memory leak in document services tests, because `stack` property is lazy-calculated since it does a lot of work (as far as I can say, mostly in `Error.prepareStackTrace`, so using callsites should help)