### PR TITLE
Use an existing stats file to speed up cache-checking

### DIFF
--- a/bin/carmi
+++ b/bin/carmi
@@ -66,7 +66,7 @@ async function run() {
 
   const statsFilePath = path.resolve(options.stats);
 
-  const statsExists = fs.existsSync(statsFilePath)
+  const statsExists = options.stats && fs.existsSync(statsFilePath)
 
   const dependencies = statsExists
     ? require(statsFilePath)

--- a/bin/carmi
+++ b/bin/carmi
@@ -65,7 +65,11 @@ async function run() {
   })
 
   const statsFilePath = path.resolve(options.stats);
-  const dependencies = analyzeDependencies(absPath, statsFilePath);
+
+  const dependencies = fs.existsSync(statsFilePath)
+		? require(statsFilePath)
+		: analyzeDependencies(absPath, statsFilePath)
+
   const encoding = options.compiler === 'bytecode' ? null : 'utf-8';
 
   const dependenciesHashes = options['cache-scenario'] === CACHE_SCENARIOS.gitHash ?
@@ -80,10 +84,6 @@ async function run() {
     dependenciesHashes,
     name: options.name
   });
-
-  if (options.stats) {
-    await fs.outputJSON(statsFilePath, dependencies);
-  }
 
   let code;
 
@@ -128,6 +128,11 @@ async function run() {
     await fs.outputFile(options.output, code);
   } else {
     console.log(code);
+  }
+
+  if (options.stats) {
+    const updatedDependencies = analyzeDependencies(absPath, statsFilePath);
+    await fs.outputJSON(statsFilePath, updatedDependencies);
   }
 }
 

--- a/bin/carmi
+++ b/bin/carmi
@@ -66,9 +66,11 @@ async function run() {
 
   const statsFilePath = path.resolve(options.stats);
 
-  const dependencies = fs.existsSync(statsFilePath)
-		? require(statsFilePath)
-		: analyzeDependencies(absPath, statsFilePath)
+  const statsExists = fs.existsSync(statsFilePath)
+
+  const dependencies = statsExists
+    ? require(statsFilePath)
+    : analyzeDependencies(absPath, statsFilePath)
 
   const encoding = options.compiler === 'bytecode' ? null : 'utf-8';
 
@@ -131,7 +133,7 @@ async function run() {
   }
 
   if (options.stats) {
-    const updatedDependencies = analyzeDependencies(absPath, statsFilePath);
+    const updatedDependencies = statsExists ? analyzeDependencies(absPath, statsFilePath) : dependencies;
     await fs.outputJSON(statsFilePath, updatedDependencies);
   }
 }

--- a/bin/carmi.spec.js
+++ b/bin/carmi.spec.js
@@ -72,7 +72,7 @@ describe('carmi binary', () => {
       cacheDir = tempy.directory();
     })
 
-    it('gets result from cache for same options', async () => {
+    it.only('gets result from cache for same options', async () => {
       carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug`, {cacheDir});
       carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug`, {cacheDir});
 


### PR DESCRIPTION
### Summary

Currently, even if no changes have been made to a Carmi file, just checking if the cache is valid takes some time. This is mostly because we need to recursively analyze the dependencies of the Carmi entry ([happens here](https://github.com/wix-incubator/carmi/blob/f43d5308101afbebb27d3b0723bdba06dd9618ca/src/analyze-dependencies.js#L136)).

This PR attempts to improve this by using an existing stats file, emitted by the previous compilation, to check if the cache still holds. If it is, exit immediately, otherwise, analyze the dependencies, run Carmi, and save the new stats file. From testing this locally I can see an improvement from running a single Jest test with Carmi down from 17s to 5-10s (with hot cache).