### PR TITLE
Use babel-register to collect dependencies during runtime instead of statically analyzing files

### DIFF
--- a/bin/carmi
+++ b/bin/carmi
@@ -57,7 +57,7 @@ async function run() {
 
   const absPath = path.resolve(process.cwd(), options.source);
 
-  const dependencies = [];
+  const collectDependencies = [];
 
   require('@babel/register')({
     rootMode: 'upward',
@@ -67,7 +67,7 @@ async function run() {
       // collect dependencies as we run, note that this ignores `node_modules`
       // but can be moved up so its not
       function(filepath) {
-        dependencies.push(filepath)
+        collectDependencies.push(filepath)
         return false
       },
     ],
@@ -80,11 +80,11 @@ async function run() {
 
   const dependencies = statsExists
     ? require(statsFilePath)
-    : analyzeDependencies(absPath, statsFilePath)
+    : null
 
   const encoding = options.compiler === 'bytecode' ? null : 'utf-8';
 
-  const dependenciesHashes = options['cache-scenario'] === CACHE_SCENARIOS.gitHash ?
+  const dependenciesHashes = options['cache-scenario'] === CACHE_SCENARIOS.gitHash && dependencies ?
     getDependenciesHashes(dependencies) :
     null;
 
@@ -100,7 +100,7 @@ async function run() {
   let code;
 
   // We are using fallback to mtime check if scenario is `git-hash`, but getting hashes was resulted in error.
-  const upToDate = Boolean(dependenciesHashes) || isUpToDate(dependencies, cacheFilePath);
+  const upToDate = Boolean(dependenciesHashes) || (dependencies && isUpToDate(dependencies, cacheFilePath));
   const useCache = !options['no-cache'] && fs.existsSync(cacheFilePath) && upToDate;
   if (useCache) {
     // return from cache
@@ -143,8 +143,7 @@ async function run() {
   }
 
   if (options.stats) {
-    const updatedDependencies = statsExists ? analyzeDependencies(absPath, statsFilePath) : dependencies;
-    await fs.outputJSON(statsFilePath, updatedDependencies);
+    await fs.outputJSON(statsFilePath, collectDependencies);
   }
 }
 

--- a/bin/carmi
+++ b/bin/carmi
@@ -57,6 +57,8 @@ async function run() {
 
   const absPath = path.resolve(process.cwd(), options.source);
 
+  const dependencies = [];
+
   require('@babel/register')({
     rootMode: 'upward',
     extensions: ['.ts', '.js'],

--- a/bin/carmi
+++ b/bin/carmi
@@ -60,8 +60,16 @@ async function run() {
   require('@babel/register')({
     rootMode: 'upward',
     extensions: ['.ts', '.js'],
-    ignore: [/node_modules/],
-    envName: 'carmi'
+    ignore: [
+      /node_modules/,
+      // collect dependencies as we run, note that this ignores `node_modules`
+      // but can be moved up so its not
+      function(filepath) {
+        dependencies.push(filepath)
+        return false
+      },
+    ],
+    envName: 'carmi',
   })
 
   const statsFilePath = path.resolve(options.stats);

--- a/bin/carmi
+++ b/bin/carmi
@@ -65,7 +65,11 @@ async function run() {
   })
 
   const statsFilePath = path.resolve(options.stats);
-  const dependencies = analyzeDependencies(absPath, statsFilePath);
+
+  const dependencies = fs.existsSync(statsFilePath)
+		? require(statsFilePath)
+		: analyzeDependencies(absPath, statsFilePath)
+
   const encoding = options.compiler === 'bytecode' ? null : 'utf-8';
 
   const dependenciesHashes = options['cache-scenario'] === CACHE_SCENARIOS.gitHash ?
@@ -80,10 +84,6 @@ async function run() {
     dependenciesHashes,
     name: options.name
   });
-
-  if (options.stats) {
-    await fs.outputJSON(statsFilePath, dependencies);
-  }
 
   let code;
 
@@ -128,6 +128,11 @@ async function run() {
     await fs.outputFile(options.output, code);
   } else {
     console.log(code);
+  }
+
+  if (options.stats) {
+    const updatedDependencies = analyzeDependencies(absPath, statsFilePath);
+    await fs.outputJSON(statsFilePath, updatedDependencies);
   }
 }
 

--- a/bin/carmi
+++ b/bin/carmi
@@ -66,9 +66,11 @@ async function run() {
 
   const statsFilePath = path.resolve(options.stats);
 
-  const dependencies = fs.existsSync(statsFilePath)
-		? require(statsFilePath)
-		: analyzeDependencies(absPath, statsFilePath)
+  const statsExists = fs.existsSync(statsFilePath)
+
+  const dependencies = statsExists
+    ? require(statsFilePath)
+    : analyzeDependencies(absPath, statsFilePath)
 
   const encoding = options.compiler === 'bytecode' ? null : 'utf-8';
 
@@ -131,7 +133,7 @@ async function run() {
   }
 
   if (options.stats) {
-    const updatedDependencies = analyzeDependencies(absPath, statsFilePath);
+    const updatedDependencies = statsExists ? analyzeDependencies(absPath, statsFilePath) : dependencies;
     await fs.outputJSON(statsFilePath, updatedDependencies);
   }
 }

--- a/bin/carmi.spec.js
+++ b/bin/carmi.spec.js
@@ -67,57 +67,58 @@ describe('carmi binary', () => {
   describe('caching', () => {
     let carmiCompileCalls;
     let cacheDir;
+    const statsPath = tempy.file({extension: 'json'})
     beforeEach(() => {
       carmiCompileCalls = 0;
       cacheDir = tempy.directory();
     })
 
     it('gets result from cache for same options', async () => {
-      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug`, {cacheDir});
-      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug`, {cacheDir});
+      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug --stats=${statsPath}`, {cacheDir});
+      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug --stats=${statsPath}`, {cacheDir});
 
       expect(carmiCompileCalls).toBe(1);
     });
 
     it('works with `cache-scenario=mtime` param result from cache for same options', async () => {
-      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug --cache-scenario=mtime`, {cacheDir});
-      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug --cache-scenario=mtime`, {cacheDir});
+      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug --cache-scenario=mtime --stats=${statsPath}`, {cacheDir});
+      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug --cache-scenario=mtime --stats=${statsPath}`, {cacheDir});
 
       expect(carmiCompileCalls).toBe(1);
     });
 
     it('works with `cache-scenario=git-hash` result from cache if file has the same git hash', async () => {
-      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug --cache-scenario=git-hash`, {cacheDir});
-      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug --cache-scenario=git-hash`, {cacheDir});
+      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug --cache-scenario=git-hash --stats=${statsPath}`, {cacheDir});
+      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug --cache-scenario=git-hash --stats=${statsPath}`, {cacheDir});
 
       expect(carmiCompileCalls).toBe(1);
     });
 
     it('works with `cache-scenario=git-hash` result from cache if file has different git hashes', async () => {
-      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug --cache-scenario=git-hash`, {cacheDir});
-      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug --cache-scenario=git-hash`, {cacheDir, withRandomGitHash: true});
+      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug --cache-scenario=git-hash --stats=${statsPath}`, {cacheDir});
+      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug --cache-scenario=git-hash --stats=${statsPath}`, {cacheDir, withRandomGitHash: true});
 
       expect(carmiCompileCalls).toBe(2);
     });
 
     it('uses fallback tos `cache-scenario=mtime` if `git ls-tree` command failed', async () => {
-      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug --cache-scenario=git-hash`, {cacheDir, errorStage: 'git-hash'});
-      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug --cache-scenario=git-hash`, {cacheDir, errorStage: 'git-hash'});
+      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug --cache-scenario=git-hash --stats=${statsPath}`, {cacheDir, errorStage: 'git-hash'});
+      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --debug --cache-scenario=git-hash --stats=${statsPath}`, {cacheDir, errorStage: 'git-hash'});
 
       expect(carmiCompileCalls).toBe(1);
     });
 
     it('doesn\'t get result from cache if debug argument was changed', async () => {
-      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --debug`, {cacheDir});
-      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL}`, {cacheDir});
+      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --debug --stats=${statsPath}`, {cacheDir});
+      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --stats=${statsPath}`, {cacheDir});
 
       expect(carmiCompileCalls).toBe(2);
     });
 
     it('doesn\'t override cache for different options', async () => {
-      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs`, {cacheDir});
-      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format iife`, {cacheDir});
-      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs`, {cacheDir});
+      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --stats=${statsPath}`, {cacheDir});
+      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format iife --stats=${statsPath}`, {cacheDir});
+      carmiCompileCalls += await getCompileCalls(`--source ${CARMI_MODEL} --format cjs --stats=${statsPath}`, {cacheDir});
 
       expect(carmiCompileCalls).toBe(2);
     });

--- a/loader.js
+++ b/loader.js
@@ -51,7 +51,16 @@ async function CarmiLoader(loader) {
 	} catch (e) {
 		err = e || new Error(`Error compiling ${options.source}`)
 	} finally {
-		Object.keys(require(statsPath)).forEach((filePath) => {
+		let stats = require(statsPath);
+
+		// Before https://github.com/wix-incubator/carmi/pull/283 stats used to be
+		// an object. This helps not have a migration for those that already have a
+		// json file created.
+		if (typeof stats === 'object') {
+			stats = Object.keys(stats);
+		}
+
+		stats.forEach((filePath) => {
 			// Add those modules as loader dependencies
 			// See https://webpack.js.org/contribute/writing-a-loader/#loader-dependencies
 			loader.addDependency(filePath)

--- a/src/__tests__/analyze-dependencies.js
+++ b/src/__tests__/analyze-dependencies.js
@@ -56,7 +56,7 @@ describe('analyze-dependencies', () => {
   it('should isUpToDate when output is new', async () => {
     await fsTouch(res('esm/a.output.js'))
     const deps = analyzeDependencies(res('esm/a.carmi.js'))
-    const upToDate = isUpToDate(deps, res('esm/a.output.js'))
+    const upToDate = isUpToDate(Object.keys(deps), res('esm/a.output.js'))
     expect(upToDate).toEqual(true)
   })
 

--- a/src/analyze-dependencies.js
+++ b/src/analyze-dependencies.js
@@ -161,9 +161,7 @@ const isEveryFileBefore = (files, time) => files.every(f => mtime(f) < time)
  * @param {string} cacheFilePath
  * @return {boolean}
  */
-function isUpToDate(deps, cacheFilePath) {
-  const depsArray = Object.keys(deps)
-
+function isUpToDate(depsArray, cacheFilePath) {
   try {
     const outTime = mtime(cacheFilePath)
     return isEveryFileBefore(depsArray, outTime)
@@ -172,9 +170,8 @@ function isUpToDate(deps, cacheFilePath) {
   }
 }
 
-const getDependenciesHashes = (dependencies) => {
+const getDependenciesHashes = (depsArray) => {
   try {
-    const depsArray = Object.keys(dependencies);
     return execSync(`git ls-tree --abbrev=7 --full-name -r HEAD ${depsArray.join(' ')}`, {encoding: 'utf8'}).split('\n').reduce((total, item) => {
       if (item) {
         const [, , hash] = item.split(/\s/);


### PR DESCRIPTION
### Summary

Based on #282, please see before continuing.

This PR makes a somewhat radical change to how Carmi analyzes dependencies in an attempt of improving performance.

Currently, Carmi uses a function to recursively statically analyze the dependencies of the entry file and its dependants. This takes time (quite a bit on a large project) and creates issues with supporting difficult-to-analyze expressions (e.g. `require('./foo/' + bar)`).

Instead of statically analyzing files, I'm instead using the fact that we already run the code, and use `@babel/register` to transpile files, and patch a small hook to it to collect the dependencies while Carmi runs the code (which it does anyway). This makes it 100% bullet-proof and saves us the time of actually analyzing anything.

Following #282, we can use the previous stats file if it exists, since dependencies are only collected after running Carmi has already finished.

Testing this locally, it reduces the initial (without cache) run (compared to the linked PR) from 90s down to 75s.